### PR TITLE
fix: buff duration uses 1d4 + INT mod, remove in-combat rest

### DIFF
--- a/src/controllers/combat_controller.py
+++ b/src/controllers/combat_controller.py
@@ -1,7 +1,7 @@
 """Turn-based combat controller.
 
 Handles initiative, turn order, action resolution for all combat actions:
-Attack, Multi-Attack, Cast Spell, Use Item, Flee, Rest, and Jester's Gamble.
+Attack, Multi-Attack, Cast Spell, Use Item, Flee, and Jester's Gamble.
 """
 
 import random
@@ -12,13 +12,18 @@ from src.models.monster import Monster
 from src.models.spell import Spell, elemental_multiplier
 
 
+def roll_buff_duration(caster) -> int:
+    """Roll buff duration: 1d4 + (caster INT modifier // 2), minimum 1."""
+    int_mod = caster.get_stat_mod("INT")
+    return max(1, random.randint(1, 4) + int_mod // 2)
+
+
 class CombatAction(str, Enum):
     ATTACK = "attack"
     MULTI_ATTACK = "multi_attack"
     CAST_SPELL = "cast_spell"
     USE_ITEM = "use_item"
     FLEE = "flee"
-    REST = "rest"
     GAMBLE = "gamble"  # Jester only
 
 
@@ -235,8 +240,9 @@ class CombatController:
 
         if spell.spell_type == "buff_stat":
             stat = spell.buff_stat or "STR"
-            self.player.apply_buff(stat, spell.buff_value, spell.buff_duration)
-            msg = f"You cast {spell.name}! +{spell.buff_value} {stat} for {spell.buff_duration} turns."
+            duration = roll_buff_duration(self.player)
+            self.player.apply_buff(stat, spell.buff_value, duration)
+            msg = f"You cast {spell.name}! +{spell.buff_value} {stat} for {duration} turns."
             self.log.append(msg)
             self.player.tick_buffs()
             self.advance_turn()
@@ -345,20 +351,6 @@ class CombatController:
             self.advance_turn()
             return {"success": False, "message": msg, "damage": damage}
 
-    def player_rest(self) -> dict:
-        """Skip turn for small HP/hunger/thirst recovery."""
-        hp_restore = random.randint(1, 4)
-        hunger_restore = 2
-        thirst_restore = 2
-        self.player.health = min(self.player.max_health, self.player.health + hp_restore)
-        self.player.hunger = min(self.player.max_hunger, self.player.hunger + hunger_restore)
-        self.player.thirst = min(self.player.max_thirst, self.player.thirst + thirst_restore)
-        msg = f"You rest and recover {hp_restore} HP, {hunger_restore} hunger, {thirst_restore} thirst."
-        self.log.append(msg)
-        self.player.tick_buffs()
-        self.advance_turn()
-        return {"success": True, "message": msg}
-
     def player_gamble(self) -> dict:
         """Jester's Gamble: roll on random effect table, LUCK influences distribution."""
         if not self.player.player_class or self.player.player_class.archetype != "jester":
@@ -393,8 +385,9 @@ class CombatController:
             msg += f" — You heal {heal} HP!"
         elif effect_key == "buff_self":
             stat = random.choice(["STR", "DEX", "CON", "INT", "WIS"])
-            self.player.apply_buff(stat, 2, 3)
-            msg += f" — +2 {stat} for 3 turns!"
+            duration = roll_buff_duration(self.player)
+            self.player.apply_buff(stat, 2, duration)
+            msg += f" — +2 {stat} for {duration} turns!"
         elif effect_key == "damage_self":
             damage = random.randint(1, 6)
             self.player.health = max(0, self.player.health - damage)

--- a/src/views/combat_view.py
+++ b/src/views/combat_view.py
@@ -134,7 +134,7 @@ class CombatView:
     # Action menu
     # ------------------------------------------------------------------
 
-    ACTIONS = ["Attack", "Multi-Attack", "Cast Spell", "Use Item", "Flee", "Rest", "Gamble"]
+    ACTIONS = ["Attack", "Multi-Attack", "Cast Spell", "Use Item", "Flee", "Gamble"]
 
     def _draw_action_menu(self, combat: CombatController, selected: int,
                           selected_target: int, selecting_target: bool):

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -26,6 +26,7 @@ from src.models.spell import (
 from src.controllers.combat_controller import (
     CombatController,
     CombatState,
+    roll_buff_duration,
 )
 
 
@@ -517,24 +518,6 @@ class TestCombatEndConditions:
 
 
 # ---------------------------------------------------------------------------
-# Rest action
-# ---------------------------------------------------------------------------
-
-class TestRest:
-    def test_rest_recovers_stats(self, warrior, weak_monster):
-        warrior.health = 50
-        warrior.hunger = 50
-        warrior.thirst = 50
-        cc = CombatController(warrior, [weak_monster])
-        cc.combatants = [cc.player_combatant] + [c for c in cc.combatants if not c.is_player]
-        cc.turn_index = 0
-        cc.player_rest()
-        assert warrior.health > 50
-        assert warrior.hunger == 52
-        assert warrior.thirst == 52
-
-
-# ---------------------------------------------------------------------------
 # Use Item in combat
 # ---------------------------------------------------------------------------
 
@@ -572,6 +555,67 @@ class TestBuffs:
         assert len(healer.active_buffs) == 1
         healer.tick_buffs()
         assert len(healer.active_buffs) == 0
+
+
+# ---------------------------------------------------------------------------
+# Buff duration roll (1d4 + INT mod // 2)
+# ---------------------------------------------------------------------------
+
+class TestBuffDuration:
+    def test_roll_buff_duration_uses_int_mod(self, healer, weak_monster):
+        """Duration should be 1d4 + (INT modifier // 2), minimum 1."""
+        # healer has INT=10 → mod 0 → 0 // 2 = 0, so duration = 1d4 + 0 = 1..4
+        durations = set()
+        for seed in range(50):
+            random.seed(seed)
+            d = roll_buff_duration(healer)
+            assert 1 <= d <= 4
+            durations.add(d)
+        assert len(durations) > 1  # not all the same
+
+    def test_high_int_increases_duration(self):
+        """High INT should add to the duration."""
+        p = _make_player("mage", dict(STR=8, DEX=12, CON=10, INT=18, WIS=12, CHA=10, LUCK=10))
+        # INT=18 → mod +4 → 4 // 2 = 2, so duration = 1d4 + 2 = 3..6
+        for seed in range(50):
+            random.seed(seed)
+            d = roll_buff_duration(p)
+            assert 3 <= d <= 6
+
+    def test_low_int_floors_at_one(self):
+        """Even with negative INT mod, duration should be at least 1."""
+        p = _make_player("warrior", dict(STR=16, DEX=14, CON=14, INT=4, WIS=8, CHA=10, LUCK=10))
+        # INT=4 → mod -3 → -3 // 2 = -2, raw = 1d4 + (-2) → could be -1..2
+        # But min is 1
+        for seed in range(50):
+            random.seed(seed)
+            d = roll_buff_duration(p)
+            assert d >= 1
+
+    def test_buff_spell_uses_rolled_duration(self, healer, weak_monster):
+        """Casting a buff spell should apply a rolled duration, not hardcoded 3."""
+        healer.spells = [
+            Spell(
+                name="Fortify", spell_type="buff_stat", element="light", stat="WIS",
+                buff_stat="CON", buff_value=2, buff_duration=3,
+                hunger_cost=0, thirst_cost=5, targets="self",
+            ),
+        ]
+        # Run many trials — duration should vary (not always 3)
+        durations = set()
+        for seed in range(50):
+            random.seed(seed)
+            healer.active_buffs = []
+            healer.thirst = 100
+            m = Monster(id="m", name="Goblin", hp=100, max_hp=100, ac=10, damage_dice=4)
+            cc = CombatController(healer, [m])
+            cc.combatants = [cc.player_combatant] + [c for c in cc.combatants if not c.is_player]
+            cc.turn_index = 0
+            cc.player_cast_spell(0, 0)
+            if healer.active_buffs:
+                durations.add(healer.active_buffs[0].turns_remaining)
+        # Should have more than one unique duration value
+        assert len(durations) > 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -607,7 +607,7 @@ class TestBuffDuration:
             random.seed(seed)
             healer.active_buffs = []
             healer.thirst = 100
-            m = Monster(id="m", name="Goblin", hp=100, max_hp=100, ac=10, damage_dice=4)
+            m = Monster(id="m", species="Goblin", hp=100, max_hp=100, ac=10, damage_dice=4)
             cc = CombatController(healer, [m])
             cc.combatants = [cc.player_combatant] + [c for c in cc.combatants if not c.is_player]
             cc.turn_index = 0


### PR DESCRIPTION
Buff duration was hardcoded to 3 turns. Now rolls 1d4 + (caster INT modifier // 2) at cast time, both for buff_stat spells and Jester Gamble buff_self. Minimum duration is 1.

Removed REST from CombatAction enum, player_rest method, and combat view action menu — rest is out-of-combat only (Phase 9 survival).

Updated tests: removed TestRest, added TestBuffDuration (4 cases).