### PR TITLE
feat: Build save/load system with player menu and load screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ data/saves/
 state.json
 CLAUDE.md
 CLAUDE.local.md
+saves/

--- a/.gitignore
+++ b/.gitignore
@@ -174,6 +174,7 @@ data/maze/
 data/events/
 data/quests/
 data/manifest.json
+data/saves/
 
 # Gas Town (added by gt)
 .runtime/

--- a/main.py
+++ b/main.py
@@ -7,8 +7,11 @@ Usage:
 """
 
 import argparse
+import logging
 import os
 import time
+
+logger = logging.getLogger(__name__)
 
 import pygame
 
@@ -181,27 +184,33 @@ def setup_game_from_save(screen, font, save_state):
             npc.prepare(maze_environment=maze.environment)
             npcs.append(npc)
 
-    # --- Restore events ---
-    events = registry.event_registry
-    for eid, saved_evt in save_state.event_states.items():
-        if eid in events:
-            events[eid].resolved = saved_evt.get("resolved", False)
-            # Restore monster HP for combat events
-            if hasattr(events[eid], 'monsters') and "monster_states" in saved_evt:
-                for i, ms in enumerate(saved_evt["monster_states"]):
-                    if i < len(events[eid].monsters):
-                        events[eid].monsters[i].hp = ms.get("hp", events[eid].monsters[i].hp)
-                        events[eid].monsters[i].status_effects = ms.get("status_effects", {})
-                events[eid].combat_started = saved_evt.get("combat_started", False)
-                events[eid].player_fled = saved_evt.get("player_fled", False)
+    # --- Restore events and quests (only if registry matches save seed) ---
+    events = {}
+    quests = {}
+    if has_pregen:
+        events = registry.event_registry
+        for eid, saved_evt in save_state.event_states.items():
+            if eid in events:
+                events[eid].resolved = saved_evt.get("resolved", False)
+                if hasattr(events[eid], 'monsters') and "monster_states" in saved_evt:
+                    for i, ms in enumerate(saved_evt["monster_states"]):
+                        if i < len(events[eid].monsters):
+                            events[eid].monsters[i].hp = ms.get("hp", events[eid].monsters[i].hp)
+                            events[eid].monsters[i].status_effects = ms.get("status_effects", {})
+                    events[eid].combat_started = saved_evt.get("combat_started", False)
+                    events[eid].player_fled = saved_evt.get("player_fled", False)
 
-    # --- Restore quests ---
-    quests = registry.quest_registry
-    for qid, saved_q in save_state.quest_states.items():
-        if qid in quests:
-            quests[qid].status = saved_q.get("status", "not_started")
-            if hasattr(quests[qid], 'current_step') and "current_step" in saved_q:
-                quests[qid].current_step = saved_q["current_step"]
+        quests = registry.quest_registry
+        for qid, saved_q in save_state.quest_states.items():
+            if qid in quests:
+                quests[qid].status = saved_q.get("status", "not_started")
+                if hasattr(quests[qid], 'current_step') and "current_step" in saved_q:
+                    quests[qid].current_step = saved_q["current_step"]
+    else:
+        logger.warning(
+            "Registry does not match save seed %d; events and quests will be empty.",
+            save_state.seed,
+        )
 
     # --- Build controller ---
     gc = GameController(screen, font, maze, player, npcs, dialogue_box, events, quests)
@@ -250,7 +259,8 @@ def main():
 
     # --- Screen state machine ---
     screen_ctrl = ScreenController(ScreenState.START)
-    start_view = StartView(screen, font, has_saves=save_manager.has_saves())
+    _cached_has_saves = save_manager.has_saves()
+    start_view = StartView(screen, font, has_saves=_cached_has_saves)
     class_select_view = None
     room_intro_view = None
     load_game_view = None
@@ -265,7 +275,7 @@ def main():
 
     def _handle_start() -> str | None:
         nonlocal class_select_view, load_game_view, load_source
-        start_view.has_saves = save_manager.has_saves()
+        start_view.has_saves = _cached_has_saves
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 return "quit"
@@ -355,12 +365,11 @@ def main():
         result = game_controller.run()
 
         if result == "open_menu":
-            # Open player menu overlay
-            can_save = not game_controller.is_in_combat
+            can_save = not game_controller.has_active_overlay
             player_menu_view = PlayerMenuView(
                 screen, font,
                 can_save=can_save,
-                has_saves=save_manager.has_saves(),
+                has_saves=_cached_has_saves,
             )
             screen_ctrl.push(ScreenState.PLAYER_MENU)
             return None
@@ -382,12 +391,14 @@ def main():
                     screen_ctrl.pop()
                     return None
                 if action == "save":
+                    nonlocal _cached_has_saves
                     elapsed = time.time() - gameplay_start_time
                     total_time = accumulated_play_time + elapsed
                     try:
                         filepath = save_manager.save_game(
                             game_controller, WORLD_SEED, total_time,
                         )
+                        _cached_has_saves = True
                         player_menu_view.set_status("Game saved!")
                     except Exception as e:
                         player_menu_view.set_status(f"Save failed: {e}", is_error=True)
@@ -440,8 +451,7 @@ def main():
                         )
                         accumulated_play_time = save_state.time_played_seconds
                         gameplay_start_time = time.time()
-                        # Clear the screen stack and go to gameplay
-                        screen_ctrl._stack = [ScreenState.GAMEPLAY]
+                        screen_ctrl.reset_to(ScreenState.GAMEPLAY)
                     except Exception as e:
                         load_game_view.error_message = f"Load failed: {e}"
                         return None

--- a/main.py
+++ b/main.py
@@ -8,6 +8,7 @@ Usage:
 
 import argparse
 import os
+import time
 
 import pygame
 
@@ -25,6 +26,9 @@ from src.controllers.screen_controller import ScreenController, ScreenState
 from src.views.start_view import StartView
 from src.views.class_select_view import ClassSelectView
 from src.views.room_intro_view import RoomIntroView
+from src.views.player_menu_view import PlayerMenuView
+from src.views.load_game_view import LoadGameView
+from src.systems import save_manager
 
 NPC_CLASS_MAP = {
     "StaticNPC": StaticNPC,
@@ -51,7 +55,7 @@ def run_generation():
 
 
 def setup_game(screen, font, player_name="Adventurer", selected_class=None):
-    """Load game data and create all game objects. Returns (game_controller,)."""
+    """Load game data and create all game objects. Returns GameController."""
     has_pregen = registry.has_manifest() and registry.manifest_matches_seed(WORLD_SEED)
 
     dialogue_box = DialogueBox(screen, font)
@@ -128,6 +132,90 @@ def setup_game(screen, font, player_name="Adventurer", selected_class=None):
     return GameController(screen, font, maze, player, npcs, dialogue_box, events, quests)
 
 
+def setup_game_from_save(screen, font, save_state):
+    """Restore a full game from a SaveState. Returns GameController."""
+    from src.models.follower import Follower
+
+    dialogue_box = DialogueBox(screen, font)
+
+    # --- Restore maze ---
+    maze = Maze()
+    maze.grid = [list(row) for row in save_state.maze_grid]
+    maze.environment = save_state.maze_environment
+    maze.environment_name = save_state.maze_environment_name
+
+    # --- Restore player ---
+    player = save_manager.deserialize_player(save_state.player_data)
+
+    # --- Restore followers ---
+    player.followers = [Follower(**fd) for fd in save_state.follower_data]
+
+    # --- Restore NPCs (merge saved mutable state onto base templates) ---
+    npcs = []
+    saved_npc_map = {s["id"]: s for s in save_state.npc_states}
+
+    has_pregen = registry.has_manifest() and registry.manifest_matches_seed(save_state.seed)
+    if has_pregen:
+        for npc_data in registry.get_active_npcs():
+            cls = NPC_CLASS_MAP.get(npc_data.get("type", "StaticNPC"), StaticNPC)
+            kwargs = dict(npc_data)
+            kwargs.pop("selected", None)
+            npc_id = kwargs.get("id", 0)
+
+            # Apply saved state
+            saved = saved_npc_map.get(npc_id, {})
+            kwargs["x"] = saved.get("x", kwargs.get("x", 0))
+            kwargs["y"] = saved.get("y", kwargs.get("y", 0))
+            if cls is RandomNPC:
+                kwargs.setdefault("home_x", saved.get("home_x", kwargs["x"]))
+                kwargs.setdefault("home_y", saved.get("home_y", kwargs["y"]))
+
+            npc = cls(**kwargs)
+            npc.interaction_history = saved.get("interaction_history", [])
+            npc.has_met_player = saved.get("has_met_player", False)
+
+            # Restore merchant shop inventory
+            if hasattr(npc, 'shop_inventory') and "shop_inventory" in saved:
+                npc.shop_inventory = saved["shop_inventory"]
+
+            npc.prepare(maze_environment=maze.environment)
+            npcs.append(npc)
+
+    # --- Restore events ---
+    events = registry.event_registry
+    for eid, saved_evt in save_state.event_states.items():
+        if eid in events:
+            events[eid].resolved = saved_evt.get("resolved", False)
+            # Restore monster HP for combat events
+            if hasattr(events[eid], 'monsters') and "monster_states" in saved_evt:
+                for i, ms in enumerate(saved_evt["monster_states"]):
+                    if i < len(events[eid].monsters):
+                        events[eid].monsters[i].hp = ms.get("hp", events[eid].monsters[i].hp)
+                        events[eid].monsters[i].status_effects = ms.get("status_effects", {})
+                events[eid].combat_started = saved_evt.get("combat_started", False)
+                events[eid].player_fled = saved_evt.get("player_fled", False)
+
+    # --- Restore quests ---
+    quests = registry.quest_registry
+    for qid, saved_q in save_state.quest_states.items():
+        if qid in quests:
+            quests[qid].status = saved_q.get("status", "not_started")
+            if hasattr(quests[qid], 'current_step') and "current_step" in saved_q:
+                quests[qid].current_step = saved_q["current_step"]
+
+    # --- Build controller ---
+    gc = GameController(screen, font, maze, player, npcs, dialogue_box, events, quests)
+
+    # Restore event position map from save
+    gc.event_position_map = {}
+    for key, eid in save_state.event_position_map.items():
+        parts = key.split(",")
+        if len(parts) == 2:
+            gc.event_position_map[(int(parts[0]), int(parts[1]))] = eid
+
+    return gc
+
+
 def main():
     args = parse_args()
 
@@ -162,14 +250,22 @@ def main():
 
     # --- Screen state machine ---
     screen_ctrl = ScreenController(ScreenState.START)
-    start_view = StartView(screen, font)
+    start_view = StartView(screen, font, has_saves=save_manager.has_saves())
     class_select_view = None
     room_intro_view = None
+    load_game_view = None
+    player_menu_view = None
+    game_controller = None
     selected_class = None
     player_name = "Adventurer"
+    gameplay_start_time = 0.0
+    accumulated_play_time = 0.0
+    # Track where load was opened from: "start" or "gameplay"
+    load_source = "start"
 
     def _handle_start() -> str | None:
-        nonlocal class_select_view
+        nonlocal class_select_view, load_game_view, load_source
+        start_view.has_saves = save_manager.has_saves()
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 return "quit"
@@ -182,6 +278,12 @@ def main():
                         screen_ctrl.replace(ScreenState.CLASS_SELECT)
                     else:
                         screen_ctrl.replace(ScreenState.GAMEPLAY)
+                    return None
+                if action == "load_game":
+                    saves = save_manager.list_saves()
+                    load_game_view = LoadGameView(screen, font, saves)
+                    load_source = "start"
+                    screen_ctrl.replace(ScreenState.LOAD_GAME)
                     return None
                 if action == "quit":
                     return "quit"
@@ -243,15 +345,120 @@ def main():
         return None
 
     def _handle_gameplay() -> str | None:
-        game_controller = setup_game(screen, font, player_name, selected_class)
-        game_controller.run()
+        nonlocal game_controller, gameplay_start_time, player_menu_view
+        nonlocal load_game_view, load_source
+
+        if game_controller is None:
+            game_controller = setup_game(screen, font, player_name, selected_class)
+            gameplay_start_time = time.time()
+
+        result = game_controller.run()
+
+        if result == "open_menu":
+            # Open player menu overlay
+            can_save = not game_controller.is_in_combat
+            player_menu_view = PlayerMenuView(
+                screen, font,
+                can_save=can_save,
+                has_saves=save_manager.has_saves(),
+            )
+            screen_ctrl.push(ScreenState.PLAYER_MENU)
+            return None
+
+        # Game loop ended (window closed)
         return "quit"
+
+    def _handle_player_menu() -> str | None:
+        nonlocal game_controller, player_menu_view
+        nonlocal load_game_view, load_source, gameplay_start_time
+        nonlocal accumulated_play_time
+
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                return "quit"
+            if event.type == pygame.KEYDOWN:
+                action = player_menu_view.handle_input(event)
+                if action == "back":
+                    screen_ctrl.pop()
+                    return None
+                if action == "save":
+                    elapsed = time.time() - gameplay_start_time
+                    total_time = accumulated_play_time + elapsed
+                    try:
+                        filepath = save_manager.save_game(
+                            game_controller, WORLD_SEED, total_time,
+                        )
+                        player_menu_view.set_status("Game saved!")
+                    except Exception as e:
+                        player_menu_view.set_status(f"Save failed: {e}", is_error=True)
+                    return None
+                if action == "load":
+                    saves = save_manager.list_saves()
+                    load_game_view = LoadGameView(screen, font, saves)
+                    load_source = "gameplay"
+                    screen_ctrl.push(ScreenState.LOAD_GAME)
+                    return None
+
+        # Draw the game underneath, then the menu overlay
+        if game_controller:
+            current_time = pygame.time.get_ticks()
+            game_controller.draw(current_time)
+        player_menu_view.draw()
+        pygame.display.flip()
+        clock.tick(60)
+        return None
+
+    def _handle_load_game() -> str | None:
+        nonlocal game_controller, gameplay_start_time, accumulated_play_time
+        nonlocal load_game_view
+
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                return "quit"
+            if event.type == pygame.KEYDOWN:
+                result = load_game_view.handle_input(event)
+                if result is None:
+                    pass
+                elif result["action"] == "back":
+                    if load_source == "start":
+                        screen_ctrl.replace(ScreenState.START)
+                    else:
+                        # Pop back to player menu
+                        screen_ctrl.pop()
+                    return None
+                elif result["action"] == "load":
+                    filepath = result["filepath"]
+                    save_state = save_manager.load_game(filepath)
+                    if save_state is None:
+                        load_game_view.error_message = "Failed to load save file (corrupt or invalid)."
+                        return None
+
+                    # Restore game from save
+                    try:
+                        game_controller = setup_game_from_save(
+                            screen, font, save_state,
+                        )
+                        accumulated_play_time = save_state.time_played_seconds
+                        gameplay_start_time = time.time()
+                        # Clear the screen stack and go to gameplay
+                        screen_ctrl._stack = [ScreenState.GAMEPLAY]
+                    except Exception as e:
+                        load_game_view.error_message = f"Load failed: {e}"
+                        return None
+                    return None
+
+        load_game_view.draw()
+        pygame.display.flip()
+        clock.tick(60)
+        return None
 
     screen_handlers: dict[ScreenState, callable] = {
         ScreenState.START: _handle_start,
         ScreenState.CLASS_SELECT: _handle_class_select,
         ScreenState.ROOM_INTRO: _handle_room_intro,
         ScreenState.GAMEPLAY: _handle_gameplay,
+        ScreenState.PLAYER_MENU: _handle_player_menu,
+        ScreenState.LOAD_GAME: _handle_load_game,
     }
 
     running = True

--- a/main.py
+++ b/main.py
@@ -11,8 +11,6 @@ import logging
 import os
 import time
 
-logger = logging.getLogger(__name__)
-
 import pygame
 
 from config import (
@@ -32,6 +30,8 @@ from src.views.room_intro_view import RoomIntroView
 from src.views.player_menu_view import PlayerMenuView
 from src.views.load_game_view import LoadGameView
 from src.systems import save_manager
+
+logger = logging.getLogger(__name__)
 
 NPC_CLASS_MAP = {
     "StaticNPC": StaticNPC,
@@ -395,7 +395,7 @@ def main():
                     elapsed = time.time() - gameplay_start_time
                     total_time = accumulated_play_time + elapsed
                     try:
-                        filepath = save_manager.save_game(
+                        save_manager.save_game(
                             game_controller, WORLD_SEED, total_time,
                         )
                         _cached_has_saves = True

--- a/src/controllers/game_controller.py
+++ b/src/controllers/game_controller.py
@@ -45,6 +45,10 @@ class GameController:
         # Combat target selection
         self.combat_target_index = 0
 
+        # Player menu / save-load state
+        self.player_menu_active = False
+        self.pending_action = None  # Set to "save", "load", "quit" to signal main loop
+
         self.game_view = GameView(screen, font, dialogue_box)
 
     def _build_event_position_map(self):
@@ -73,8 +77,17 @@ class GameController:
                     quest.status = "completed"
                     self.player.complete_quest(qid)
 
-    def run(self):
-        """Main game loop."""
+    @property
+    def is_in_combat(self) -> bool:
+        """True if player is in an active combat encounter."""
+        return (
+            self.dialogue_box.event_active
+            or self.dialogue_box.dialogue_active
+            or self.shop_active
+        )
+
+    def run(self) -> str | None:
+        """Main game loop. Returns action: 'menu_save', 'menu_load', or None."""
         clock = pygame.time.Clock()
 
         while self.running:
@@ -85,7 +98,13 @@ class GameController:
             pygame.display.flip()
             clock.tick(60)
 
-        pygame.quit()
+            # Check if game controller wants to hand control back
+            if self.pending_action:
+                action = self.pending_action
+                self.pending_action = None
+                return action
+
+        return None
 
     def handle_events(self):
         """Handle all pygame events."""
@@ -217,6 +236,11 @@ class GameController:
             self._talk_to_follower()
             return
 
+        # Player menu (save/load)
+        if event.key == pygame.K_TAB:
+            self.pending_action = "open_menu"
+            return
+
         # Available in all builds (including packaged exe) for troubleshooting
         if event.key == pygame.K_F1:
             self.debug_reveal = not self.debug_reveal
@@ -226,6 +250,8 @@ class GameController:
             if self.quest_log_active:
                 self.quest_log_active = False
                 return
+            # Esc also opens menu in normal gameplay
+            self.pending_action = "open_menu"
             return
 
     def _handle_event_input(self, event):

--- a/src/controllers/game_controller.py
+++ b/src/controllers/game_controller.py
@@ -5,6 +5,7 @@ from src.models.npc import RandomNPC, AggressiveNPC, MerchantNPC
 from src.models.items import EscortItem
 from src.models.follower import Follower
 from src.registry import registry
+from src.utils.conversation_utils import has_dialogue_choices
 
 
 class GameController:
@@ -184,6 +185,18 @@ class GameController:
                 self.dialogue_box.update_dialogue(self.dialogue_box.user_message)
                 return
             if self.dialogue_box.input_active:
+                # Numeric selection for offline_static dialogue choices
+                if has_dialogue_choices(self.current_npc):
+                    tree = self.current_npc.dialogue_tree
+                    nodes = tree.get("nodes", {})
+                    current_id = tree.get("_current", "start")
+                    node = nodes.get(current_id, nodes.get("start", {}))
+                    choices = node.get("choices", [])
+                    for i in range(len(choices)):
+                        if event.key == getattr(pygame, f'K_{i+1}', None):
+                            self.dialogue_box.update_dialogue(str(i + 1))
+                            return
+                    return
                 if event.key == pygame.K_BACKSPACE:
                     self.dialogue_box.user_message = self.dialogue_box.user_message[:-1]
                 else:

--- a/src/controllers/game_controller.py
+++ b/src/controllers/game_controller.py
@@ -79,8 +79,8 @@ class GameController:
                     self.player.complete_quest(qid)
 
     @property
-    def is_in_combat(self) -> bool:
-        """True if player is in an active combat encounter."""
+    def has_active_overlay(self) -> bool:
+        """True if any modal UI is open (dialogue, event, or shop)."""
         return (
             self.dialogue_box.event_active
             or self.dialogue_box.dialogue_active
@@ -88,7 +88,7 @@ class GameController:
         )
 
     def run(self) -> str | None:
-        """Main game loop. Returns action: 'menu_save', 'menu_load', or None."""
+        """Main game loop. Returns 'open_menu' when the player opens the menu, or None on window close."""
         clock = pygame.time.Clock()
 
         while self.running:
@@ -192,11 +192,13 @@ class GameController:
                     current_id = tree.get("_current", "start")
                     node = nodes.get(current_id, nodes.get("start", {}))
                     choices = node.get("choices", [])
-                    for i in range(len(choices)):
+                    # Keys 1-9 only; pygame has no K_10+ constants
+                    for i in range(min(len(choices), 9)):
                         if event.key == getattr(pygame, f'K_{i+1}', None):
                             self.dialogue_box.update_dialogue(str(i + 1))
                             return
-                    return
+                    if event.key != pygame.K_ESCAPE:
+                        return
                 if event.key == pygame.K_BACKSPACE:
                     self.dialogue_box.user_message = self.dialogue_box.user_message[:-1]
                 else:

--- a/src/controllers/screen_controller.py
+++ b/src/controllers/screen_controller.py
@@ -51,6 +51,10 @@ class ScreenController:
         else:
             self._stack.append(state)
 
+    def reset_to(self, state: ScreenState):
+        """Clear the stack and set a single screen."""
+        self._stack = [state]
+
     @property
     def depth(self) -> int:
         return len(self._stack)

--- a/src/controllers/screen_controller.py
+++ b/src/controllers/screen_controller.py
@@ -9,6 +9,7 @@ class ScreenState(Enum):
     ROOM_INTRO = "room_intro"
     GAMEPLAY = "gameplay"
     PLAYER_MENU = "player_menu"
+    LOAD_GAME = "load_game"
     COMBAT = "combat"
     ENCOUNTER = "encounter"
     DIALOGUE = "dialogue"

--- a/src/models/save.py
+++ b/src/models/save.py
@@ -1,8 +1,6 @@
 """Save state serialization model — full game state snapshot."""
 
-from datetime import datetime
 from pydantic import BaseModel, Field
-from typing import Optional
 
 
 class SaveMetadata(BaseModel):

--- a/src/models/save.py
+++ b/src/models/save.py
@@ -1,15 +1,55 @@
-"""Save state serialization model."""
+"""Save state serialization model — full game state snapshot."""
 
+from datetime import datetime
 from pydantic import BaseModel, Field
+from typing import Optional
+
+
+class SaveMetadata(BaseModel):
+    """Display info shown in save file lists."""
+    character_name: str = "Adventurer"
+    character_class: str = ""
+    room_level: int = 1
+    time_played_seconds: float = 0.0
+    last_save_date: str = ""
+    seed: int = -1
 
 
 class SaveState(BaseModel):
     """Full game state snapshot for save/load."""
+
+    # Version for forward-compat validation
+    version: int = 1
+
+    # Metadata (for display in load screen)
+    metadata: SaveMetadata = Field(default_factory=SaveMetadata)
+
+    # World identity
     seed: int = -1
     room_id: str = "room_1"
+
+    # Player state
     player_data: dict = Field(default_factory=dict)
-    inventory_data: dict = Field(default_factory=dict)
-    quest_log: list[dict] = Field(default_factory=list)
+
+    # Maze state
+    maze_grid: list = Field(default_factory=list)
+    maze_environment: str = ""
+    maze_environment_name: str = ""
+
+    # NPC states (position, dialogue history, has_met_player, shop inventory)
     npc_states: list[dict] = Field(default_factory=list)
-    time_ticks: int = 0
-    rooms_cleared: list[str] = Field(default_factory=list)
+
+    # Event states (which are resolved, monster HP for active combats)
+    event_states: dict = Field(default_factory=dict)
+
+    # Quest states (status, current_step for multi-step)
+    quest_states: dict = Field(default_factory=dict)
+
+    # Follower data
+    follower_data: list[dict] = Field(default_factory=list)
+
+    # Event position map (tile positions to event IDs)
+    event_position_map: dict = Field(default_factory=dict)
+
+    # Timing
+    time_played_seconds: float = 0.0

--- a/src/systems/save_manager.py
+++ b/src/systems/save_manager.py
@@ -12,7 +12,7 @@ from typing import Optional
 
 from src.models.save import SaveState, SaveMetadata
 
-SAVE_DIR = "saves"
+SAVE_DIR = os.path.join("data", "saves")
 
 
 def _ensure_save_dir():
@@ -251,7 +251,7 @@ def save_game(game_controller, seed: int, time_played_seconds: float = 0.0) -> s
     metadata = SaveMetadata(
         character_name=char_name,
         character_class=char_class,
-        room_level=1,
+        room_level=getattr(game_controller, 'current_room_level', 1),
         time_played_seconds=time_played_seconds,
         last_save_date=datetime.now().strftime("%Y-%m-%d %H:%M"),
         seed=seed,
@@ -294,6 +294,10 @@ def save_game(game_controller, seed: int, time_played_seconds: float = 0.0) -> s
 
 def load_game(filepath: str) -> Optional[SaveState]:
     """Load a save file. Returns SaveState or None if invalid."""
+    real_path = os.path.realpath(filepath)
+    real_save_dir = os.path.realpath(SAVE_DIR)
+    if not real_path.startswith(real_save_dir + os.sep):
+        return None
     try:
         with open(filepath, 'r') as f:
             data = json.load(f)
@@ -354,5 +358,6 @@ def delete_save(filepath: str) -> bool:
 
 
 def has_saves() -> bool:
-    """Check if any valid save files exist."""
-    return len(list_saves()) > 0
+    """Check if any save files exist (fast check, no JSON parsing)."""
+    _ensure_save_dir()
+    return any(f.endswith(".json") for f in os.listdir(SAVE_DIR))

--- a/src/systems/save_manager.py
+++ b/src/systems/save_manager.py
@@ -1,1 +1,358 @@
-"""Save/load serialization manager — stub for later phases."""
+"""Save/load serialization manager.
+
+Handles serializing full game state to JSON and restoring it.
+Save files go to saves/ directory, keyed by seed + character name + class.
+"""
+
+import json
+import os
+import re
+from datetime import datetime
+from typing import Optional
+
+from src.models.save import SaveState, SaveMetadata
+
+SAVE_DIR = "saves"
+
+
+def _ensure_save_dir():
+    os.makedirs(SAVE_DIR, exist_ok=True)
+
+
+def _save_filename(seed: int, character_name: str, character_class: str) -> str:
+    """Generate save filename: save_{seed}_{name}_{class}.json"""
+    safe_name = re.sub(r'[^a-zA-Z0-9_]', '_', character_name.lower())
+    safe_class = re.sub(r'[^a-zA-Z0-9_]', '_', character_class.lower())
+    return f"save_{seed}_{safe_name}_{safe_class}.json"
+
+
+def _save_path(seed: int, character_name: str, character_class: str) -> str:
+    return os.path.join(SAVE_DIR, _save_filename(seed, character_name, character_class))
+
+
+# ---------------------------------------------------------------------------
+# Serialization helpers
+# ---------------------------------------------------------------------------
+
+def serialize_player(player) -> dict:
+    """Serialize PlayerCharacter to a dict."""
+    data = {
+        "x": player.x,
+        "y": player.y,
+        "name": player.name,
+        "level": player.level,
+        "health": player.health,
+        "hunger": player.hunger,
+        "thirst": player.thirst,
+        "max_health": player.max_health,
+        "max_hunger": player.max_hunger,
+        "max_thirst": player.max_thirst,
+        "speed": player.speed,
+        "max_speed": player.max_speed,
+        "money": player.money,
+        "equipped_weapon": player.equipped_weapon,
+        "armor": player.armor,
+        "selected_item_index": player.selected_item_index,
+        "active_quests": list(player.active_quests),
+        "completed_quests": list(player.completed_quests),
+        "failed_quests": list(player.failed_quests),
+        "learned_spells": list(player.learned_spells),
+        "profile_image": player.profile_image,
+    }
+
+    # Player class
+    if player.player_class:
+        data["player_class"] = player.player_class.model_dump()
+
+    # Inventory - serialize each item with its type
+    inv = {}
+    for item_name, item in player.inventory.items():
+        item_dict = item.model_dump()
+        item_dict["_item_type"] = type(item).__name__
+        inv[item_name] = item_dict
+    data["inventory"] = inv
+
+    # Abilities and spells
+    data["abilities"] = [
+        a.model_dump() if hasattr(a, 'model_dump') else a
+        for a in player.abilities
+    ]
+    data["spells"] = [
+        s.model_dump() if hasattr(s, 'model_dump') else s
+        for s in player.spells
+    ]
+
+    # Active buffs
+    data["active_buffs"] = [b.model_dump() for b in player.active_buffs]
+
+    return data
+
+
+def deserialize_player(data: dict):
+    """Restore a PlayerCharacter from saved data."""
+    from src.models.player import (
+        PlayerCharacter, PlayerClass, ActiveBuff, Ability, Spell,
+    )
+
+    # Reconstruct inventory
+    inventory = {}
+    for item_name, item_dict in data.get("inventory", {}).items():
+        item_type = item_dict.pop("_item_type", "Item")
+        inventory[item_name] = _reconstruct_item(item_dict, item_type)
+
+    # Reconstruct player class
+    player_class = None
+    if "player_class" in data and data["player_class"]:
+        player_class = PlayerClass(**data["player_class"])
+
+    # Reconstruct abilities and spells
+    abilities = [
+        Ability(**a) if isinstance(a, dict) else a
+        for a in data.get("abilities", [])
+    ]
+    spells = [
+        Spell(**s) if isinstance(s, dict) else s
+        for s in data.get("spells", [])
+    ]
+    active_buffs = [ActiveBuff(**b) for b in data.get("active_buffs", [])]
+
+    player = PlayerCharacter(
+        x=data.get("x", 0),
+        y=data.get("y", 0),
+        name=data.get("name", "Adventurer"),
+        player_class=player_class,
+        level=data.get("level", 1),
+        health=data.get("health", 100),
+        hunger=data.get("hunger", 100),
+        thirst=data.get("thirst", 100),
+        max_health=data.get("max_health", 100),
+        max_hunger=data.get("max_hunger", 100),
+        max_thirst=data.get("max_thirst", 100),
+        speed=data.get("speed", 1.0),
+        max_speed=data.get("max_speed", 2.0),
+        money=data.get("money", 0),
+        equipped_weapon=data.get("equipped_weapon"),
+        armor=data.get("armor", 0),
+        selected_item_index=data.get("selected_item_index", 0),
+        active_quests=data.get("active_quests", []),
+        completed_quests=data.get("completed_quests", []),
+        failed_quests=data.get("failed_quests", []),
+        learned_spells=data.get("learned_spells", []),
+        profile_image=data.get("profile_image"),
+        inventory=inventory,
+        abilities=abilities,
+        spells=spells,
+        active_buffs=active_buffs,
+    )
+    return player
+
+
+def _reconstruct_item(item_dict: dict, item_type: str):
+    """Reconstruct an Item subclass from serialized dict."""
+    from src.models.items import (
+        Item, Food, Drink, Tool, Weapon, SpellScroll, EscortItem, ItemStats,
+    )
+
+    TYPE_MAP = {
+        "Item": Item,
+        "Food": Food,
+        "Drink": Drink,
+        "Tool": Tool,
+        "Weapon": Weapon,
+        "SpellScroll": SpellScroll,
+        "EscortItem": EscortItem,
+    }
+
+    cls = TYPE_MAP.get(item_type, Item)
+
+    # Ensure item_stats is an ItemStats instance
+    stats_data = item_dict.get("item_stats", {})
+    if isinstance(stats_data, dict):
+        item_dict["item_stats"] = ItemStats(**stats_data)
+
+    # EscortItem needs tuple for target_zone
+    if cls is EscortItem and "target_zone" in item_dict:
+        tz = item_dict["target_zone"]
+        if isinstance(tz, list):
+            item_dict["target_zone"] = tuple(tz)
+
+    return cls(**item_dict)
+
+
+def serialize_npc(npc) -> dict:
+    """Serialize an NPC's mutable state."""
+    data = {
+        "id": npc.id,
+        "x": npc.x,
+        "y": npc.y,
+        "interaction_history": list(npc.interaction_history),
+        "has_met_player": npc.has_met_player,
+        "_npc_type": type(npc).__name__,
+    }
+    # MerchantNPC shop state
+    if hasattr(npc, 'shop_inventory'):
+        data["shop_inventory"] = npc.shop_inventory
+    # RandomNPC home position
+    if hasattr(npc, 'home_x'):
+        data["home_x"] = npc.home_x
+        data["home_y"] = npc.home_y
+    return data
+
+
+def serialize_event(event) -> dict:
+    """Serialize an event's mutable state."""
+    data = {
+        "id": event.id,
+        "resolved": event.resolved,
+    }
+    # For combat events, save monster HP
+    if hasattr(event, 'monsters'):
+        data["monster_states"] = [
+            {"hp": m.hp, "status_effects": dict(m.status_effects)}
+            for m in event.monsters
+        ]
+        data["combat_started"] = event.combat_started
+        data["player_fled"] = event.player_fled
+    return data
+
+
+def serialize_quest(quest) -> dict:
+    """Serialize a quest's mutable state."""
+    data = {
+        "id": quest.id,
+        "status": quest.status,
+    }
+    if hasattr(quest, 'current_step'):
+        data["current_step"] = quest.current_step
+    return data
+
+
+def serialize_follower(follower) -> dict:
+    """Serialize a Follower."""
+    return follower.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Save / Load / List / Delete
+# ---------------------------------------------------------------------------
+
+def save_game(game_controller, seed: int, time_played_seconds: float = 0.0) -> str:
+    """Save full game state. Returns the save file path."""
+    _ensure_save_dir()
+
+    player = game_controller.player
+    maze = game_controller.maze
+
+    char_name = player.name
+    char_class = (
+        player.player_class.name if player.player_class else "unknown"
+    )
+
+    metadata = SaveMetadata(
+        character_name=char_name,
+        character_class=char_class,
+        room_level=1,
+        time_played_seconds=time_played_seconds,
+        last_save_date=datetime.now().strftime("%Y-%m-%d %H:%M"),
+        seed=seed,
+    )
+
+    # Serialize event position map with string keys for JSON
+    epm = {}
+    for (x, y), eid in game_controller.event_position_map.items():
+        epm[f"{x},{y}"] = eid
+
+    state = SaveState(
+        version=1,
+        metadata=metadata,
+        seed=seed,
+        room_id="room_1",
+        player_data=serialize_player(player),
+        maze_grid=[list(row) for row in maze.grid],
+        maze_environment=maze.environment,
+        maze_environment_name=getattr(maze, 'environment_name', ''),
+        npc_states=[serialize_npc(npc) for npc in game_controller.npcs],
+        event_states={
+            eid: serialize_event(evt)
+            for eid, evt in game_controller.events.items()
+        },
+        quest_states={
+            qid: serialize_quest(q)
+            for qid, q in game_controller.quests.items()
+        },
+        follower_data=[serialize_follower(f) for f in player.followers],
+        event_position_map=epm,
+        time_played_seconds=time_played_seconds,
+    )
+
+    filepath = _save_path(seed, char_name, char_class)
+    with open(filepath, 'w') as f:
+        json.dump(state.model_dump(), f, indent=2, default=str)
+
+    return filepath
+
+
+def load_game(filepath: str) -> Optional[SaveState]:
+    """Load a save file. Returns SaveState or None if invalid."""
+    try:
+        with open(filepath, 'r') as f:
+            data = json.load(f)
+        return SaveState(**data)
+    except (json.JSONDecodeError, KeyError, TypeError, FileNotFoundError):
+        return None
+    except Exception:
+        return None
+
+
+def validate_save(filepath: str) -> bool:
+    """Check if a save file is valid without fully loading it."""
+    try:
+        with open(filepath, 'r') as f:
+            data = json.load(f)
+        return "version" in data and "player_data" in data
+    except Exception:
+        return False
+
+
+def list_saves() -> list[dict]:
+    """List all save files with metadata for display.
+
+    Returns list of dicts with: filepath, character_name, character_class,
+    room_level, time_played_seconds, last_save_date, seed.
+    """
+    _ensure_save_dir()
+    saves = []
+    for filename in sorted(os.listdir(SAVE_DIR)):
+        if not filename.endswith(".json"):
+            continue
+        filepath = os.path.join(SAVE_DIR, filename)
+        try:
+            with open(filepath, 'r') as f:
+                data = json.load(f)
+            meta = data.get("metadata", {})
+            saves.append({
+                "filepath": filepath,
+                "character_name": meta.get("character_name", "Unknown"),
+                "character_class": meta.get("character_class", ""),
+                "room_level": meta.get("room_level", 1),
+                "time_played_seconds": meta.get("time_played_seconds", 0),
+                "last_save_date": meta.get("last_save_date", ""),
+                "seed": meta.get("seed", -1),
+            })
+        except Exception:
+            continue  # Skip corrupt files
+    return saves
+
+
+def delete_save(filepath: str) -> bool:
+    """Delete a save file. Returns True on success."""
+    try:
+        os.remove(filepath)
+        return True
+    except OSError:
+        return False
+
+
+def has_saves() -> bool:
+    """Check if any valid save files exist."""
+    return len(list_saves()) > 0

--- a/src/utils/conversation_utils.py
+++ b/src/utils/conversation_utils.py
@@ -90,6 +90,17 @@ def _static_dialogue_response(npc, player_input: str) -> str:
     return f"{npc.name}: {prompt}"
 
 
+def has_dialogue_choices(npc) -> bool:
+    """Return True if the NPC's current dialogue tree node has choices."""
+    if GAME_MODE != "offline_static" or not npc or not npc.dialogue_tree:
+        return False
+    tree = npc.dialogue_tree
+    nodes = tree.get("nodes", {})
+    current_node_id = tree.get("_current", "start")
+    node = nodes.get(current_node_id, nodes.get("start", {}))
+    return bool(node.get("choices"))
+
+
 def _extract_response(raw: str) -> str:
     """Extract the usable NPC response from raw LLM output."""
     if "##Output:" in raw:

--- a/src/views/load_game_view.py
+++ b/src/views/load_game_view.py
@@ -1,0 +1,167 @@
+"""Load game screen — shows save file list for selection.
+
+Used both from the start screen and from the player menu.
+"""
+
+import pygame
+from config import SCREEN_WIDTH, SCREEN_HEIGHT, BLACK
+
+TITLE_COLOR = (220, 180, 60)
+SELECTED_COLOR = (255, 255, 100)
+UNSELECTED_COLOR = (180, 180, 180)
+HEADER_COLOR = (150, 150, 200)
+ERROR_COLOR = (200, 100, 100)
+
+
+def _format_time(seconds: float) -> str:
+    """Format seconds into HH:MM:SS."""
+    h = int(seconds) // 3600
+    m = (int(seconds) % 3600) // 60
+    s = int(seconds) % 60
+    if h > 0:
+        return f"{h}h {m}m {s}s"
+    if m > 0:
+        return f"{m}m {s}s"
+    return f"{s}s"
+
+
+class LoadGameView:
+    """Renders the save file list and handles selection."""
+
+    def __init__(self, screen, font, saves: list[dict]):
+        """
+        saves: list of dicts from save_manager.list_saves(), each with:
+            filepath, character_name, character_class, room_level,
+            time_played_seconds, last_save_date, seed
+        """
+        self.screen = screen
+        self.font = font
+        self.title_font = pygame.font.Font(None, 48)
+        self.small_font = pygame.font.Font(None, 24)
+        self.saves = saves
+        self.selected_index = 0
+        self.error_message = ""
+        self.scroll_offset = 0
+        self.max_visible = 6
+
+    def draw(self):
+        self.screen.fill(BLACK)
+
+        # Title
+        title_surface = self.title_font.render("Load Game", True, TITLE_COLOR)
+        title_x = (SCREEN_WIDTH - title_surface.get_width()) // 2
+        self.screen.blit(title_surface, (title_x, 30))
+
+        if not self.saves:
+            no_saves = self.font.render(
+                "No save files found.", True, (120, 120, 120),
+            )
+            x = (SCREEN_WIDTH - no_saves.get_width()) // 2
+            self.screen.blit(no_saves, (x, SCREEN_HEIGHT // 2))
+            hint = self.font.render(
+                "Esc: Back", True, (100, 100, 100),
+            )
+            self.screen.blit(hint, (10, SCREEN_HEIGHT - 30))
+            return
+
+        # Column header
+        header = "  Name              Class           Level   Time      Saved"
+        header_surface = self.small_font.render(header, True, HEADER_COLOR)
+        self.screen.blit(header_surface, (40, 80))
+
+        # Draw separator
+        pygame.draw.line(
+            self.screen, HEADER_COLOR, (40, 100), (SCREEN_WIDTH - 40, 100),
+        )
+
+        # Save entries
+        line_height = 50
+        start_y = 110
+        visible_saves = self.saves[
+            self.scroll_offset:self.scroll_offset + self.max_visible
+        ]
+
+        for i, save in enumerate(visible_saves):
+            actual_idx = i + self.scroll_offset
+            selected = actual_idx == self.selected_index
+            color = SELECTED_COLOR if selected else UNSELECTED_COLOR
+            prefix = "> " if selected else "  "
+
+            name = save["character_name"][:16].ljust(16)
+            cls = save["character_class"][:14].ljust(14)
+            level = f"Rm {save['room_level']}".ljust(8)
+            time_str = _format_time(save["time_played_seconds"]).ljust(10)
+            date = save["last_save_date"]
+
+            line = f"{prefix}{name}  {cls}  {level}{time_str}{date}"
+            text_surface = self.font.render(line, True, color)
+            self.screen.blit(text_surface, (30, start_y + i * line_height))
+
+            # Seed info on second line if selected
+            if selected:
+                seed_text = f"   Seed: {save['seed']}"
+                seed_surface = self.small_font.render(
+                    seed_text, True, (100, 100, 100),
+                )
+                self.screen.blit(
+                    seed_surface,
+                    (50, start_y + i * line_height + 25),
+                )
+
+        # Scroll indicators
+        if self.scroll_offset > 0:
+            arrow = self.font.render("^ more saves above", True, (100, 100, 100))
+            self.screen.blit(arrow, (SCREEN_WIDTH // 2 - 80, start_y - 20))
+        if self.scroll_offset + self.max_visible < len(self.saves):
+            arrow = self.font.render(
+                "v more saves below", True, (100, 100, 100),
+            )
+            self.screen.blit(
+                arrow,
+                (SCREEN_WIDTH // 2 - 80,
+                 start_y + self.max_visible * line_height + 5),
+            )
+
+        # Error message
+        if self.error_message:
+            err = self.font.render(self.error_message, True, ERROR_COLOR)
+            err_x = (SCREEN_WIDTH - err.get_width()) // 2
+            self.screen.blit(err, (err_x, SCREEN_HEIGHT - 70))
+
+        # Hints
+        hint_text = "Enter: Load  |  Esc: Back"
+        hint = self.font.render(hint_text, True, (100, 100, 100))
+        self.screen.blit(hint, (10, SCREEN_HEIGHT - 30))
+
+    def handle_input(self, event) -> dict | None:
+        """Process keydown. Returns:
+        - {"action": "load", "filepath": str, "save": dict} on selection
+        - {"action": "back"} on escape
+        - None otherwise
+        """
+        if event.key == pygame.K_ESCAPE:
+            return {"action": "back"}
+
+        if not self.saves:
+            return None
+
+        if event.key == pygame.K_UP:
+            self.selected_index = max(0, self.selected_index - 1)
+            if self.selected_index < self.scroll_offset:
+                self.scroll_offset = self.selected_index
+        elif event.key == pygame.K_DOWN:
+            self.selected_index = min(
+                len(self.saves) - 1, self.selected_index + 1,
+            )
+            if self.selected_index >= self.scroll_offset + self.max_visible:
+                self.scroll_offset = (
+                    self.selected_index - self.max_visible + 1
+                )
+        elif event.key == pygame.K_RETURN:
+            save = self.saves[self.selected_index]
+            return {
+                "action": "load",
+                "filepath": save["filepath"],
+                "save": save,
+            }
+        return None

--- a/src/views/player_menu_view.py
+++ b/src/views/player_menu_view.py
@@ -1,0 +1,117 @@
+"""Player menu screen — Save and Load options during gameplay.
+
+Opened with Tab key during normal gameplay (not during combat/events).
+"""
+
+import pygame
+from config import SCREEN_WIDTH, SCREEN_HEIGHT, BLACK
+
+MENU_ITEMS = ["Save Game", "Load Game", "Back"]
+
+TITLE_COLOR = (220, 180, 60)
+SELECTED_COLOR = (255, 255, 100)
+UNSELECTED_COLOR = (180, 180, 180)
+DISABLED_COLOR = (80, 80, 80)
+STATUS_COLOR = (100, 200, 100)
+ERROR_COLOR = (200, 100, 100)
+
+
+class PlayerMenuView:
+    """Minimal player menu with Save / Load / Back."""
+
+    def __init__(self, screen, font, can_save=True, has_saves=False):
+        self.screen = screen
+        self.font = font
+        self.title_font = pygame.font.Font(None, 48)
+        self.selected_index = 0
+        self.can_save = can_save
+        self.has_saves = has_saves
+        self.status_message = ""
+        self.status_is_error = False
+
+    def set_status(self, message: str, is_error: bool = False):
+        self.status_message = message
+        self.status_is_error = is_error
+
+    def draw(self):
+        # Semi-transparent overlay
+        overlay = pygame.Surface((SCREEN_WIDTH, SCREEN_HEIGHT))
+        overlay.fill(BLACK)
+        overlay.set_alpha(200)
+        self.screen.blit(overlay, (0, 0))
+
+        # Title
+        title_surface = self.title_font.render("Menu", True, TITLE_COLOR)
+        title_x = (SCREEN_WIDTH - title_surface.get_width()) // 2
+        self.screen.blit(title_surface, (title_x, SCREEN_HEIGHT // 4))
+
+        # Menu items
+        line_height = self.font.get_linesize()
+        start_y = SCREEN_HEIGHT // 2 - 30
+
+        for i, item in enumerate(MENU_ITEMS):
+            disabled = self._is_disabled(i)
+            if disabled:
+                color = DISABLED_COLOR
+            elif i == self.selected_index:
+                color = SELECTED_COLOR
+            else:
+                color = UNSELECTED_COLOR
+
+            prefix = "> " if i == self.selected_index else "  "
+            label = item
+            if disabled:
+                if item == "Save Game":
+                    label += " (in combat)"
+                elif item == "Load Game":
+                    label += " (no saves)"
+            text_surface = self.font.render(f"{prefix}{label}", True, color)
+            text_x = (SCREEN_WIDTH - text_surface.get_width()) // 2
+            self.screen.blit(
+                text_surface,
+                (text_x, start_y + i * (line_height + 10)),
+            )
+
+        # Status message
+        if self.status_message:
+            msg_color = ERROR_COLOR if self.status_is_error else STATUS_COLOR
+            msg_surface = self.font.render(self.status_message, True, msg_color)
+            msg_x = (SCREEN_WIDTH - msg_surface.get_width()) // 2
+            self.screen.blit(
+                msg_surface,
+                (msg_x, start_y + len(MENU_ITEMS) * (line_height + 10) + 20),
+            )
+
+        # Hint
+        hint_text = "Tab/Esc: Close"
+        hint_surface = self.font.render(hint_text, True, (100, 100, 100))
+        self.screen.blit(hint_surface, (10, SCREEN_HEIGHT - 30))
+
+    def _is_disabled(self, index: int) -> bool:
+        item = MENU_ITEMS[index]
+        if item == "Save Game" and not self.can_save:
+            return True
+        if item == "Load Game" and not self.has_saves:
+            return True
+        return False
+
+    def handle_input(self, event) -> str | None:
+        """Process keydown. Returns: 'save', 'load', 'back', or None."""
+        if event.key in (pygame.K_TAB, pygame.K_ESCAPE):
+            return "back"
+
+        if event.key == pygame.K_UP:
+            self.selected_index = (self.selected_index - 1) % len(MENU_ITEMS)
+        elif event.key == pygame.K_DOWN:
+            self.selected_index = (self.selected_index + 1) % len(MENU_ITEMS)
+        elif event.key == pygame.K_RETURN:
+            if self._is_disabled(self.selected_index):
+                return None
+            selected = MENU_ITEMS[self.selected_index]
+            if selected == "Save Game":
+                return "save"
+            elif selected == "Load Game":
+                return "load"
+            elif selected == "Back":
+                return "back"
+        return None

--- a/src/views/start_view.py
+++ b/src/views/start_view.py
@@ -1,4 +1,4 @@
-"""Start screen — New Game, Load Game (stub), Tutorial (stub), Quit."""
+"""Start screen — New Game, Load Game, Tutorial (stub), Quit."""
 
 import pygame
 from config import SCREEN_WIDTH, SCREEN_HEIGHT, BLACK
@@ -10,16 +10,18 @@ MENU_ITEMS = ["New Game", "Load Game", "Tutorial", "Quit"]
 TITLE_COLOR = (220, 180, 60)
 SELECTED_COLOR = (255, 255, 100)
 UNSELECTED_COLOR = (180, 180, 180)
+DISABLED_COLOR = (80, 80, 80)
 
 
 class StartView:
     """Renders the start menu and handles selection state."""
 
-    def __init__(self, screen, font):
+    def __init__(self, screen, font, has_saves=False):
         self.screen = screen
         self.font = font
         self.title_font = pygame.font.Font(None, 64)
         self.selected_index = 0
+        self.has_saves = has_saves
 
     def draw(self):
         self.screen.fill(BLACK)
@@ -33,34 +35,56 @@ class StartView:
         line_height = self.font.get_linesize()
         start_y = SCREEN_HEIGHT // 2
         for i, item in enumerate(MENU_ITEMS):
-            color = SELECTED_COLOR if i == self.selected_index else UNSELECTED_COLOR
+            disabled = self._is_disabled(i)
+            if disabled:
+                color = DISABLED_COLOR
+            elif i == self.selected_index:
+                color = SELECTED_COLOR
+            else:
+                color = UNSELECTED_COLOR
             prefix = "> " if i == self.selected_index else "  "
             text_surface = self.font.render(f"{prefix}{item}", True, color)
             text_x = (SCREEN_WIDTH - text_surface.get_width()) // 2
             self.screen.blit(text_surface, (text_x, start_y + i * (line_height + 10)))
 
-        # Stub labels
-        stub_items = {"Load Game", "Tutorial"}
-        for i, item in enumerate(MENU_ITEMS):
-            if item in stub_items and i == self.selected_index:
-                hint = self.font.render("(coming soon)", True, (120, 120, 120))
-                hint_x = (SCREEN_WIDTH - hint.get_width()) // 2
-                self.screen.blit(hint, (hint_x, start_y + len(MENU_ITEMS) * (line_height + 10) + 20))
+        # Hint for disabled/stub items
+        hint_text = None
+        selected_item = MENU_ITEMS[self.selected_index]
+        if selected_item == "Tutorial":
+            hint_text = "(coming soon)"
+        elif selected_item == "Load Game" and not self.has_saves:
+            hint_text = "(no save files found)"
+
+        if hint_text:
+            hint = self.font.render(hint_text, True, (120, 120, 120))
+            hint_x = (SCREEN_WIDTH - hint.get_width()) // 2
+            self.screen.blit(hint, (hint_x, start_y + len(MENU_ITEMS) * (line_height + 10) + 20))
+
+    def _is_disabled(self, index: int) -> bool:
+        item = MENU_ITEMS[index]
+        if item == "Load Game" and not self.has_saves:
+            return True
+        if item == "Tutorial":
+            return True
+        return False
 
     def handle_input(self, event) -> str | None:
         """Process a keydown event. Returns an action string or None.
 
-        Actions: "new_game", "quit", or None (no action taken).
+        Actions: "new_game", "load_game", "quit", or None.
         """
         if event.key == pygame.K_UP:
             self.selected_index = (self.selected_index - 1) % len(MENU_ITEMS)
         elif event.key == pygame.K_DOWN:
             self.selected_index = (self.selected_index + 1) % len(MENU_ITEMS)
         elif event.key == pygame.K_RETURN:
+            if self._is_disabled(self.selected_index):
+                return None
             selected = MENU_ITEMS[self.selected_index]
             if selected == "New Game":
                 return "new_game"
+            elif selected == "Load Game":
+                return "load_game"
             elif selected == "Quit":
                 return "quit"
-            # Load Game and Tutorial are stubs — no action
         return None

--- a/tests/test_conversation_utils.py
+++ b/tests/test_conversation_utils.py
@@ -1,6 +1,8 @@
 from unittest.mock import patch
 from src.models.npc import StaticNPC
-from src.utils.conversation_utils import generate_npc_response, _extract_response
+from src.utils.conversation_utils import (
+    generate_npc_response, _extract_response, has_dialogue_choices,
+)
 
 
 def _make_npc(**overrides):
@@ -106,3 +108,73 @@ class TestExtractResponse:
     def test_output_prefix_takes_last_occurrence(self):
         raw = "##Output: first\n##Output: second"
         assert _extract_response(raw) == "second"
+
+
+# ---------------------------------------------------------------------------
+# has_dialogue_choices
+# ---------------------------------------------------------------------------
+
+class TestHasDialogueChoices:
+    @patch("src.utils.conversation_utils.GAME_MODE", "offline_static")
+    def test_true_when_node_has_choices(self):
+        npc = _make_npc()
+        npc.dialogue_tree = {
+            "nodes": {
+                "start": {
+                    "prompt": "Hello!",
+                    "choices": [
+                        {"text": "Hi", "next_node_id": "n2"},
+                        {"text": "Bye", "next_node_id": "end"},
+                    ],
+                },
+            },
+        }
+        assert has_dialogue_choices(npc) is True
+
+    @patch("src.utils.conversation_utils.GAME_MODE", "offline_static")
+    def test_false_when_node_has_no_choices(self):
+        npc = _make_npc()
+        npc.dialogue_tree = {
+            "nodes": {
+                "start": {"prompt": "Farewell."},
+            },
+        }
+        assert has_dialogue_choices(npc) is False
+
+    @patch("src.utils.conversation_utils.GAME_MODE", "offline_static")
+    def test_false_when_no_dialogue_tree(self):
+        npc = _make_npc()
+        npc.dialogue_tree = None
+        assert has_dialogue_choices(npc) is False
+
+    @patch("src.utils.conversation_utils.GAME_MODE", "offline_static")
+    def test_false_when_npc_is_none(self):
+        assert has_dialogue_choices(None) is False
+
+    @patch("src.utils.conversation_utils.GAME_MODE", "online")
+    def test_false_in_online_mode(self):
+        npc = _make_npc()
+        npc.dialogue_tree = {
+            "nodes": {
+                "start": {
+                    "prompt": "Hello!",
+                    "choices": [{"text": "Hi", "next_node_id": "n2"}],
+                },
+            },
+        }
+        assert has_dialogue_choices(npc) is False
+
+    @patch("src.utils.conversation_utils.GAME_MODE", "offline_static")
+    def test_respects_current_node(self):
+        npc = _make_npc()
+        npc.dialogue_tree = {
+            "_current": "end_node",
+            "nodes": {
+                "start": {
+                    "prompt": "Hello!",
+                    "choices": [{"text": "Hi", "next_node_id": "end_node"}],
+                },
+                "end_node": {"prompt": "Goodbye."},
+            },
+        }
+        assert has_dialogue_choices(npc) is False

--- a/tests/test_dialogue_view.py
+++ b/tests/test_dialogue_view.py
@@ -1,9 +1,8 @@
 """Tests for portrait loading and display in DialogueBoxView."""
 import os
-import tempfile
 import pytest
 import pygame
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from src.views.dialogue_view import _load_portrait, _portrait_cache, DialogueBoxView
 from config import SCREEN_WIDTH, SCREEN_HEIGHT

--- a/tests/test_new_models.py
+++ b/tests/test_new_models.py
@@ -131,7 +131,7 @@ def test_save_state_defaults():
     ss = SaveState()
     assert ss.seed == -1
     assert ss.room_id == "room_1"
-    assert ss.quest_log == []
+    assert ss.version == 1
 
 
 def test_save_state_with_data():
@@ -139,10 +139,10 @@ def test_save_state_with_data():
         seed=1234,
         room_id="room_3",
         player_data={"x": 5, "y": 10, "health": 80},
-        rooms_cleared=["room_1", "room_2"],
+        quest_states={"q1": {"status": "active"}, "q2": {"status": "completed"}},
     )
     assert ss.seed == 1234
-    assert len(ss.rooms_cleared) == 2
+    assert len(ss.quest_states) == 2
 
 
 # --- DayNightCycle ---

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -1,0 +1,352 @@
+"""Tests for the save/load system."""
+
+import json
+import os
+import shutil
+import tempfile
+
+import pytest
+
+from src.models.save import SaveState, SaveMetadata
+from src.systems import save_manager
+from src.models.player import PlayerCharacter, PlayerClass, Stats, Ability, Spell, ActiveBuff
+from src.models.items import Food, Drink, Tool, Weapon, SpellScroll, ItemStats
+from src.models.follower import Follower
+
+
+@pytest.fixture
+def tmp_save_dir(monkeypatch):
+    """Use a temp directory for saves."""
+    tmpdir = tempfile.mkdtemp()
+    monkeypatch.setattr(save_manager, "SAVE_DIR", tmpdir)
+    yield tmpdir
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.fixture
+def player_with_class():
+    """Create a player with a class applied."""
+    pc = PlayerClass(
+        name="Knight",
+        archetype="warrior",
+        flavor_text="A brave knight.",
+        environment="castle",
+        stats=Stats(STR=16, DEX=12, CON=14, INT=8, WIS=10, CHA=12, LUCK=10),
+        starting_weapon="Longsword",
+        abilities=[Ability(name="Shield Bash", description="Bash with shield", stat="STR")],
+        spells=[],
+    )
+    p = PlayerCharacter(x=5, y=10, name="Gandalf")
+    p.apply_class(pc)
+    p.money = 100
+    p.health = 80
+    p.hunger = 60
+    p.thirst = 40
+    p.active_quests = ["q1", "q2"]
+    p.completed_quests = ["q0"]
+    p.failed_quests = ["q_fail"]
+    p.learned_spells = ["fireball"]
+
+    # Add items to inventory
+    food = Food(
+        category="food", name="Bread", desc="Fresh bread",
+        item_stats=ItemStats(nutrition_value=20, health_value=5),
+    )
+    weapon = Weapon(
+        category="weapon", name="Longsword", desc="A sharp blade",
+        item_stats=ItemStats(attack_dice="1d8", stat_modifier="STR", price=50),
+        weapon_type="heavy",
+    )
+    p.add_to_inventory(food)
+    p.add_to_inventory(weapon)
+    p.equipped_weapon = "Longsword"
+
+    return p
+
+
+class TestPlayerSerialization:
+    def test_serialize_deserialize_roundtrip(self, player_with_class):
+        """Player data survives a serialize -> deserialize round trip."""
+        p = player_with_class
+        data = save_manager.serialize_player(p)
+        restored = save_manager.deserialize_player(data)
+
+        assert restored.name == "Gandalf"
+        assert restored.x == 5
+        assert restored.y == 10
+        assert restored.health == 80
+        assert restored.hunger == 60
+        assert restored.thirst == 40
+        assert restored.money == 100
+        assert restored.level == 1
+        assert restored.equipped_weapon == "Longsword"
+        assert restored.active_quests == ["q1", "q2"]
+        assert restored.completed_quests == ["q0"]
+        assert restored.failed_quests == ["q_fail"]
+        assert restored.learned_spells == ["fireball"]
+
+    def test_inventory_preserved(self, player_with_class):
+        """Inventory items are properly typed after deserialization."""
+        data = save_manager.serialize_player(player_with_class)
+        restored = save_manager.deserialize_player(data)
+
+        assert "Bread" in restored.inventory
+        assert "Longsword" in restored.inventory
+        assert isinstance(restored.inventory["Bread"], Food)
+        assert isinstance(restored.inventory["Longsword"], Weapon)
+        assert restored.inventory["Bread"].item_stats.nutrition_value == 20
+        assert restored.inventory["Longsword"].weapon_type == "heavy"
+
+    def test_player_class_preserved(self, player_with_class):
+        """Player class data survives serialization."""
+        data = save_manager.serialize_player(player_with_class)
+        restored = save_manager.deserialize_player(data)
+
+        assert restored.player_class is not None
+        assert restored.player_class.name == "Knight"
+        assert restored.player_class.archetype == "warrior"
+        assert restored.player_class.stats.STR == 16
+
+    def test_abilities_preserved(self, player_with_class):
+        """Abilities survive serialization."""
+        data = save_manager.serialize_player(player_with_class)
+        restored = save_manager.deserialize_player(data)
+
+        assert len(restored.abilities) == 1
+        assert restored.abilities[0].name == "Shield Bash"
+
+    def test_empty_player_roundtrip(self):
+        """Minimal player with no class serializes cleanly."""
+        p = PlayerCharacter(x=0, y=0)
+        data = save_manager.serialize_player(p)
+        restored = save_manager.deserialize_player(data)
+
+        assert restored.name == "Adventurer"
+        assert restored.player_class is None
+        assert restored.inventory == {}
+
+
+class TestSaveMetadata:
+    def test_save_filename_generation(self):
+        filename = save_manager._save_filename(1234, "Gandalf", "Knight")
+        assert filename == "save_1234_gandalf_knight.json"
+
+    def test_save_filename_special_chars(self):
+        filename = save_manager._save_filename(42, "Sir Lancelot", "Holy Knight")
+        assert filename == "save_42_sir_lancelot_holy_knight.json"
+
+
+class TestSaveState:
+    def test_save_state_model(self):
+        """SaveState can be created with defaults."""
+        state = SaveState()
+        assert state.version == 1
+        assert state.seed == -1
+        assert state.player_data == {}
+
+    def test_save_state_with_metadata(self):
+        meta = SaveMetadata(
+            character_name="Test",
+            character_class="Warrior",
+            room_level=2,
+            time_played_seconds=3600,
+            last_save_date="2026-04-06 12:00",
+            seed=1234,
+        )
+        state = SaveState(metadata=meta, seed=1234)
+        assert state.metadata.character_name == "Test"
+        assert state.metadata.time_played_seconds == 3600
+
+
+class TestListAndHasSaves:
+    def test_list_saves_empty(self, tmp_save_dir):
+        """No saves returns empty list."""
+        assert save_manager.list_saves() == []
+
+    def test_has_saves_false(self, tmp_save_dir):
+        assert save_manager.has_saves() is False
+
+    def test_list_saves_with_file(self, tmp_save_dir):
+        """A valid save file is listed."""
+        state = SaveState(
+            metadata=SaveMetadata(
+                character_name="Hero",
+                character_class="Mage",
+                seed=42,
+            ),
+            seed=42,
+            player_data={"name": "Hero"},
+        )
+        filepath = os.path.join(tmp_save_dir, "save_42_hero_mage.json")
+        with open(filepath, 'w') as f:
+            json.dump(state.model_dump(), f)
+
+        saves = save_manager.list_saves()
+        assert len(saves) == 1
+        assert saves[0]["character_name"] == "Hero"
+        assert saves[0]["character_class"] == "Mage"
+        assert saves[0]["seed"] == 42
+
+    def test_has_saves_true(self, tmp_save_dir):
+        filepath = os.path.join(tmp_save_dir, "save_1_a_b.json")
+        state = SaveState(player_data={"name": "A"})
+        with open(filepath, 'w') as f:
+            json.dump(state.model_dump(), f)
+        assert save_manager.has_saves() is True
+
+
+class TestValidation:
+    def test_validate_valid_save(self, tmp_save_dir):
+        filepath = os.path.join(tmp_save_dir, "valid.json")
+        with open(filepath, 'w') as f:
+            json.dump({"version": 1, "player_data": {}}, f)
+        assert save_manager.validate_save(filepath) is True
+
+    def test_validate_corrupt_json(self, tmp_save_dir):
+        filepath = os.path.join(tmp_save_dir, "corrupt.json")
+        with open(filepath, 'w') as f:
+            f.write("{broken json!!!")
+        assert save_manager.validate_save(filepath) is False
+
+    def test_validate_missing_fields(self, tmp_save_dir):
+        filepath = os.path.join(tmp_save_dir, "bad.json")
+        with open(filepath, 'w') as f:
+            json.dump({"seed": 1}, f)
+        assert save_manager.validate_save(filepath) is False
+
+    def test_validate_nonexistent_file(self, tmp_save_dir):
+        assert save_manager.validate_save("/nonexistent/path.json") is False
+
+    def test_load_corrupt_returns_none(self, tmp_save_dir):
+        filepath = os.path.join(tmp_save_dir, "corrupt.json")
+        with open(filepath, 'w') as f:
+            f.write("not json")
+        assert save_manager.load_game(filepath) is None
+
+    def test_load_nonexistent_returns_none(self, tmp_save_dir):
+        assert save_manager.load_game("/no/such/file.json") is None
+
+
+class TestDeleteSave:
+    def test_delete_existing(self, tmp_save_dir):
+        filepath = os.path.join(tmp_save_dir, "delete_me.json")
+        with open(filepath, 'w') as f:
+            f.write("{}")
+        assert save_manager.delete_save(filepath) is True
+        assert not os.path.exists(filepath)
+
+    def test_delete_nonexistent(self, tmp_save_dir):
+        assert save_manager.delete_save("/no/such/file.json") is False
+
+
+class TestNpcSerialization:
+    def test_serialize_npc_basic(self):
+        from src.models.npc import StaticNPC
+        npc = StaticNPC(x=3, y=7, id=1)
+        data = save_manager.serialize_npc(npc)
+        assert data["id"] == 1
+        assert data["x"] == 3
+        assert data["y"] == 7
+        assert data["_npc_type"] == "StaticNPC"
+
+    def test_serialize_npc_with_history(self):
+        from src.models.npc import StaticNPC
+        npc = StaticNPC(x=0, y=0, id=2)
+        npc.add_turn("user", "Hello")
+        npc.add_turn("assistant", "Hi there!")
+        npc.has_met_player = True
+        data = save_manager.serialize_npc(npc)
+        assert len(data["interaction_history"]) == 2
+        assert data["has_met_player"] is True
+
+
+class TestEventSerialization:
+    def test_serialize_resolved_event(self):
+        from src.models.encounter import PuzzleEvent, EventChoice
+        evt = PuzzleEvent(
+            id="p1", name="Boulder", description="A boulder blocks the path",
+            choices=[EventChoice(text="Push it", dc=12)],
+        )
+        evt.resolved = True
+        data = save_manager.serialize_event(evt)
+        assert data["resolved"] is True
+
+    def test_serialize_combat_event(self):
+        from src.models.encounter import CombatEvent
+        from src.models.monster import Monster
+        m = Monster(id="m1", species="Goblin", hp=5, max_hp=10)
+        evt = CombatEvent(
+            id="c1", name="Goblin fight", description="Goblins!",
+            monsters=[m],
+        )
+        data = save_manager.serialize_event(evt)
+        assert data["monster_states"][0]["hp"] == 5
+
+
+class TestQuestSerialization:
+    def test_serialize_quest(self):
+        from src.models.quest import FetchQuest, QuestReward
+        q = FetchQuest(
+            id="q1", title="Find herbs", description="Get herbs",
+            giver_npc_id=1, target_items=[{"item_id": 101, "count": 2}],
+            reward=QuestReward(money=50),
+        )
+        q.status = "active"
+        data = save_manager.serialize_quest(q)
+        assert data["status"] == "active"
+
+    def test_serialize_multistep_quest(self):
+        from src.models.quest import MultiStepQuest, QuestReward
+        q = MultiStepQuest(
+            id="ms1", title="Epic chain", description="Do things",
+            giver_npc_id=1, sub_quest_ids=["s1", "s2", "s3"],
+            reward=QuestReward(),
+        )
+        q.current_step = 1
+        q.status = "active"
+        data = save_manager.serialize_quest(q)
+        assert data["current_step"] == 1
+
+
+class TestFollowerSerialization:
+    def test_serialize_follower(self):
+        f = Follower(
+            npc_id=5, name="Bob", quest_id="q1",
+            joined_in_room=1, destination_room=2,
+            personality="friendly",
+            dialogue_hints=["Stay close.", "Almost there."],
+        )
+        data = save_manager.serialize_follower(f)
+        assert data["npc_id"] == 5
+        assert data["name"] == "Bob"
+        assert data["quest_id"] == "q1"
+        assert len(data["dialogue_hints"]) == 2
+
+
+class TestItemReconstruction:
+    def test_reconstruct_food(self):
+        item = save_manager._reconstruct_item(
+            {"category": "food", "name": "Apple", "desc": "Red apple",
+             "item_stats": {"nutrition_value": 15}},
+            "Food",
+        )
+        assert isinstance(item, Food)
+        assert item.item_stats.nutrition_value == 15
+
+    def test_reconstruct_weapon(self):
+        item = save_manager._reconstruct_item(
+            {"category": "weapon", "name": "Dagger", "desc": "Sharp",
+             "item_stats": {"attack_dice": "1d4"}, "weapon_type": "light"},
+            "Weapon",
+        )
+        assert isinstance(item, Weapon)
+        assert item.weapon_type == "light"
+
+    def test_reconstruct_unknown_falls_back_to_item(self):
+        from src.models.items import Item
+        item = save_manager._reconstruct_item(
+            {"category": "misc", "name": "Rock", "desc": "A rock",
+             "item_stats": {}},
+            "UnknownType",
+        )
+        assert isinstance(item, Item)

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -9,8 +9,8 @@ import pytest
 
 from src.models.save import SaveState, SaveMetadata
 from src.systems import save_manager
-from src.models.player import PlayerCharacter, PlayerClass, Stats, Ability, Spell, ActiveBuff
-from src.models.items import Food, Drink, Tool, Weapon, SpellScroll, ItemStats
+from src.models.player import PlayerCharacter, PlayerClass, Stats, Ability
+from src.models.items import Food, Weapon, ItemStats
 from src.models.follower import Follower
 
 


### PR DESCRIPTION
## Summary
- Full save/load serialization system (player, maze, NPCs, quests, events, followers, combat records) to JSON
- Multiple save slots keyed by seed + character name + class
- PlayerMenuScreen with Save/Load options (Tab/Esc to open)
- LoadScreen integrated into StartScreen with save file browser
- Edge cases: corrupt save validation, no-saves-disabled load, no saving mid-combat
- 31 tests covering serialization roundtrips, validation, and edge cases

## Test plan
- [x] All 31 save/load tests pass
- [ ] Manual playtest: save game, quit, load from start screen
- [ ] Manual playtest: multiple save slots with different characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)