### PR TITLE
Fix Phase 1 gaps: missing config settings and manifest schema

### DIFF
--- a/TODO_EXE_PACKAGING.md
+++ b/TODO_EXE_PACKAGING.md
@@ -115,7 +115,7 @@ Bundle `game.py` + `data/` into a distributable exe labeled by world seed.
 
 - [ ] The exe filename includes the seed: `MazeWorld_seed1234` (from `config.WORLD_SEED`)
 - [ ] Optionally embed seed in the window title: `pygame.display.set_caption(f"MazeWorld - Seed {WORLD_SEED}")`
-- [ ] The `data/manifest.json` inside the bundle already records `world_seed` — this is the canonical reference
+- [ ] The `data/manifest.json` inside the bundle already records `seed` — this is the canonical reference
 
 ### 2.6 Test the packaged exe
 

--- a/config.py
+++ b/config.py
@@ -53,8 +53,8 @@ STARTING_MONEY = 50
 
 ## Audio settings
 # ------------------------------------
-MASTER_VOLUME = int(os.getenv("MASTER_VOLUME", "80"))
-MUSIC_VOLUME = int(os.getenv("MUSIC_VOLUME", "60"))
+MASTER_VOLUME = max(0, min(100, int(os.getenv("MASTER_VOLUME", "80"))))
+MUSIC_VOLUME = max(0, min(100, int(os.getenv("MUSIC_VOLUME", "60"))))
 MUSIC_BACKEND = os.getenv("MUSIC_BACKEND", "none")  # "none" | "local" | "api"
 
 ##GenAI Backend

--- a/config.py
+++ b/config.py
@@ -18,8 +18,15 @@ MAZE_WIDTH = SCREEN_WIDTH // GRID_SIZE
 MAZE_HEIGHT = (SCREEN_HEIGHT - 100- HUD_HEIGHT) // GRID_SIZE  # Leaving space for dialogue box
 WORLD_SEED = 1234 # Set to -1 for random seed
 STORY_SEED = ""  # 1-liner story prompt; empty = LLM generates freely
+NUM_ROOMS = int(os.getenv("NUM_ROOMS", "1"))
 EVENT_PERCENT = 0.1
 EVENT_DENSITY = EVENT_PERCENT  # Alias: configurable encounter density
+QUEST_DENSITY = float(os.getenv("QUEST_DENSITY", "0.1"))
+MAP_COLORS = {
+    "wall": (40, 40, 40),
+    "path": (200, 200, 200),
+    "player": (0, 120, 255),
+}
 
 # Dialogue box
 DIALOGUE_BOX_HEIGHT = 100
@@ -43,6 +50,12 @@ NUM_TOOLS = 1
 NUM_WEAPONS = 2
 NUM_SPELL_SCROLLS = 1
 STARTING_MONEY = 50
+
+## Audio settings
+# ------------------------------------
+MASTER_VOLUME = int(os.getenv("MASTER_VOLUME", "80"))
+MUSIC_VOLUME = int(os.getenv("MUSIC_VOLUME", "60"))
+MUSIC_BACKEND = os.getenv("MUSIC_BACKEND", "none")  # "none" | "local" | "api"
 
 ##GenAI Backend
 # ------------------------------------

--- a/src/generate/pipeline.py
+++ b/src/generate/pipeline.py
@@ -19,6 +19,7 @@ from config import (
 )
 from src.models.maze import Maze
 from src.models.monster import generate_encounter_monsters
+from src.generate.validator import ValidationReport
 from src.registry import registry
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -59,6 +60,77 @@ CLASS_PATH = os.path.join(DATA_DIR, "classes", "classes.json")
 MANIFEST_PATH = os.path.join(DATA_DIR, "manifest.json")
 
 _FALLBACK_STORY_SEED = "A dark cult is gathering power in the shadows, corrupting the land."
+
+
+def build_manifest(
+    *,
+    seed: int,
+    story_seed: str,
+    game_mode: str,
+    num_rooms: int,
+    environments: list[str],
+    generated_at: str,
+    validation: dict,
+    active_npc_count: int,
+    item_count: int,
+    quest_count: int,
+    event_list: list[dict],
+    npc_pool: list[dict],
+    player_portrait_path: str | None,
+    env_portrait_path: str | None,
+    environment: str,
+    env_name: str,
+    maze_width: int,
+    maze_height: int,
+    class_count: int,
+    portraits_generated: bool,
+    story_title: str,
+    faction_name: str,
+) -> dict:
+    """Build the manifest dict written to data/manifest.json.
+
+    All counting logic (images, monsters) lives here so it's testable
+    without running the full pipeline.
+    """
+    image_count = sum(1 for p in [player_portrait_path, env_portrait_path] if p)
+    image_count += sum(1 for n in npc_pool if n.get("portrait"))
+
+    monster_count = sum(
+        len(e.get("monsters", []))
+        for e in event_list if e.get("event_type") == "combat"
+    )
+
+    return {
+        "seed": seed,
+        "story_seed": story_seed,
+        "game_mode": game_mode,
+        "num_rooms": num_rooms,
+        "environments": environments,
+        "generated_at": generated_at,
+        "validation": validation,
+        "content_index": {
+            "rooms": num_rooms,
+            "npcs": active_npc_count,
+            "items": item_count,
+            "quests": quest_count,
+            "encounters": len(event_list),
+            "monsters": monster_count,
+            "images": image_count,
+            "music_tracks": 0,
+        },
+        # Extended fields (non-PDR, kept for registry/debug use)
+        "environment": environment,
+        "environment_name": env_name,
+        "maze_width": maze_width,
+        "maze_height": maze_height,
+        "npc_pool_size": len(npc_pool),
+        "class_count": class_count,
+        "portraits_generated": portraits_generated,
+        "player_portrait": player_portrait_path,
+        "environment_portrait": env_portrait_path,
+        "story_title": story_title,
+        "faction_name": faction_name,
+    }
 
 
 def _compute_zones(width: int, height: int, zone_size: int) -> list[tuple[int, int]]:
@@ -434,7 +506,9 @@ def _build_items_json(llm_result: dict, room_level: int) -> dict:
     return items
 
 
-def _validate_puzzle_tools(event_list: list[dict], reg) -> None:
+def _validate_puzzle_tools(
+    event_list: list[dict], reg, report: ValidationReport | None = None,
+) -> None:
     """Ensure puzzle events only reference tool attributes that exist in the registry."""
     from src.models.items import Tool
     available_attrs = set()
@@ -448,6 +522,12 @@ def _validate_puzzle_tools(event_list: list[dict], reg) -> None:
         for choice in event.get("choices", []):
             attr = choice.get("tool_attribute")
             if attr and attr not in available_attrs:
+                if report:
+                    report.add_warning(
+                        f"Puzzle choice referenced invalid tool_attribute '{attr}'; replaced",
+                        entity_id=event.get("id", ""),
+                        phase="events",
+                    )
                 if available_attrs:
                     choice["tool_attribute"] = random.choice(list(available_attrs))
                 else:
@@ -486,6 +566,8 @@ def generate_world():
     """Main generation pipeline. Writes all data to data/."""
     logger.info("=== MazeWorld World Generator ===")
     logger.info("Seed: %s, Mode: %s", WORLD_SEED, GAME_MODE)
+
+    report = ValidationReport(rooms_validated=NUM_ROOMS)
 
     if WORLD_SEED != -1:
         random.seed(WORLD_SEED)
@@ -662,6 +744,10 @@ def generate_world():
             beats=beats,
         )
     else:
+        report.add_major(
+            "LLM story generation failed; using template fallback",
+            phase="story",
+        )
         from src.models.story import OverarchingStory, Faction, RoomStoryBeat
         story = OverarchingStory(
             seed=story_seed,
@@ -780,7 +866,7 @@ def generate_world():
         event_list.append(event_data)
 
     # Validate puzzle events reference tools that actually exist
-    _validate_puzzle_tools(event_list, registry)
+    _validate_puzzle_tools(event_list, registry, report)
 
     event_position_map = []
     for idx, (ex, ey) in enumerate(event_positions):
@@ -905,6 +991,13 @@ def generate_world():
             if _populate_quest_fields(quest_data, quest_type, zone_x, zone_y):
                 if _validate_quest(quest_data, npc_pool, item_placements, event_list, quest_list + pool):
                     pool.append(quest_data)
+
+        if len(pool) < target_count:
+            report.add_warning(
+                f"Quest pool for zone ({zone_x},{zone_y}) filled {len(pool)}/{target_count} "
+                f"after {attempts} attempts",
+                phase="quests",
+            )
 
         # --- Ensure minimums: 1 story quest ---
         has_story = any(q.get("is_story_quest") for q in pool)
@@ -1080,6 +1173,9 @@ def generate_world():
         logger.info("Portraits generated successfully.")
     except Exception as e:
         logger.warning("Portrait generation skipped: %s", e)
+        report.add_warning(
+            f"Portrait generation skipped: {e}", phase="portraits",
+        )
         portraits_generated = False
         player_portrait_path = None
         env_portrait_path = None
@@ -1123,47 +1219,30 @@ def generate_world():
     with open(CLASS_PATH, "w") as f:
         json.dump(class_data_list, f, indent=2)
 
-    # Count generated images (portraits)
-    image_count = sum(1 for p in [player_portrait_path, env_portrait_path] if p)
-    image_count += sum(1 for n in npc_pool if n.get("portrait"))
-
-    # Count monsters across combat events
-    monster_count = sum(
-        len(e.get("monsters", []))
-        for e in event_list if e.get("event_type") == "combat"
+    manifest = build_manifest(
+        seed=WORLD_SEED,
+        story_seed=story.seed,
+        game_mode=GAME_MODE,
+        num_rooms=NUM_ROOMS,
+        environments=[maze.environment],
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        validation=report.to_dict(),
+        active_npc_count=len(active_npcs),
+        item_count=len(item_placements),
+        quest_count=len(quest_list),
+        event_list=event_list,
+        npc_pool=npc_pool,
+        player_portrait_path=player_portrait_path,
+        env_portrait_path=env_portrait_path,
+        environment=maze.environment,
+        env_name=env_name,
+        maze_width=MAZE_WIDTH,
+        maze_height=MAZE_HEIGHT,
+        class_count=len(class_data_list),
+        portraits_generated=portraits_generated,
+        story_title=story.title,
+        faction_name=story.faction.name if story.faction else "",
     )
-
-    manifest = {
-        "seed": WORLD_SEED,
-        "story_seed": story.seed,
-        "game_mode": GAME_MODE,
-        "num_rooms": NUM_ROOMS,
-        "environments": [maze.environment],
-        "generated_at": datetime.now(timezone.utc).isoformat(),
-        "validation": {"status": "passed"},
-        "content_index": {
-            "rooms": NUM_ROOMS,
-            "npcs": len(active_npcs),
-            "items": len(item_placements),
-            "quests": len(quest_list),
-            "encounters": len(event_list),
-            "monsters": monster_count,
-            "images": image_count,
-            "music_tracks": 0,
-        },
-        # Extended fields (non-PDR, kept for registry/debug use)
-        "environment": maze.environment,
-        "environment_name": env_name,
-        "maze_width": MAZE_WIDTH,
-        "maze_height": MAZE_HEIGHT,
-        "npc_pool_size": len(npc_pool),
-        "class_count": len(class_data_list),
-        "portraits_generated": portraits_generated,
-        "player_portrait": player_portrait_path,
-        "environment_portrait": env_portrait_path,
-        "story_title": story.title,
-        "faction_name": story.faction.name if story.faction else "",
-    }
     with open(MANIFEST_PATH, "w") as f:
         json.dump(manifest, f, indent=2)
 

--- a/src/generate/pipeline.py
+++ b/src/generate/pipeline.py
@@ -15,6 +15,7 @@ from tqdm import tqdm
 from config import (
     WORLD_SEED, STORY_SEED, GAME_MODE, MAZE_WIDTH, MAZE_HEIGHT,
     NUM_FOOD, NUM_DRINKS, NUM_TOOLS, NUM_WEAPONS, NUM_SPELL_SCROLLS,
+    NUM_ROOMS,
 )
 from src.models.maze import Maze
 from src.models.monster import generate_encounter_monsters
@@ -1122,25 +1123,46 @@ def generate_world():
     with open(CLASS_PATH, "w") as f:
         json.dump(class_data_list, f, indent=2)
 
+    # Count generated images (portraits)
+    image_count = sum(1 for p in [player_portrait_path, env_portrait_path] if p)
+    image_count += sum(1 for n in npc_pool if n.get("portrait"))
+
+    # Count monsters across combat events
+    monster_count = sum(
+        len(e.get("monsters", []))
+        for e in event_list if e.get("event_type") == "combat"
+    )
+
     manifest = {
-        "world_seed": WORLD_SEED,
+        "seed": WORLD_SEED,
+        "story_seed": story.seed,
+        "game_mode": GAME_MODE,
+        "num_rooms": NUM_ROOMS,
+        "environments": [maze.environment],
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "validation": {"status": "passed"},
+        "content_index": {
+            "rooms": NUM_ROOMS,
+            "npcs": len(active_npcs),
+            "items": len(item_placements),
+            "quests": len(quest_list),
+            "encounters": len(event_list),
+            "monsters": monster_count,
+            "images": image_count,
+            "music_tracks": 0,
+        },
+        # Extended fields (non-PDR, kept for registry/debug use)
         "environment": maze.environment,
         "environment_name": env_name,
         "maze_width": MAZE_WIDTH,
         "maze_height": MAZE_HEIGHT,
-        "generated_at": datetime.now(timezone.utc).isoformat(),
         "npc_pool_size": len(npc_pool),
-        "active_npc_count": len(active_npcs),
-        "quest_count": len(quest_list),
-        "event_count": len(event_list),
         "class_count": len(class_data_list),
         "portraits_generated": portraits_generated,
         "player_portrait": player_portrait_path,
         "environment_portrait": env_portrait_path,
-        "game_mode": GAME_MODE,
         "story_title": story.title,
         "faction_name": story.faction.name if story.faction else "",
-        "story_seed": story.seed,
     }
     with open(MANIFEST_PATH, "w") as f:
         json.dump(manifest, f, indent=2)

--- a/src/generate/validator.py
+++ b/src/generate/validator.py
@@ -1,1 +1,86 @@
-"""Base Validator class (rule-based + LLM). Populated in later phases."""
+"""Validation report used by the generation pipeline.
+
+The full agentic checker/validator pattern (generator -> checker -> validator ->
+world editor) described in the PDR is deferred to a later phase.  This module
+provides the ``ValidationReport`` dataclass so the pipeline can accumulate
+warnings and failures from existing rule-based checks and surface them in the
+manifest instead of hardcoding ``{"status": "passed"}``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ValidationReport:
+    """Accumulates validation findings during world generation.
+
+    Matches the PDR manifest ``validation`` block schema::
+
+        {
+            "status": "passed",
+            "rooms_validated": 1,
+            "critical_failures": 0,
+            "major_retries": 0,
+            "minor_warnings": 0,
+            "details": []
+        }
+    """
+
+    rooms_validated: int = 0
+    critical_failures: int = 0
+    major_retries: int = 0
+    minor_warnings: int = 0
+    details: list[dict] = field(default_factory=list)
+
+    # -- Mutation helpers -----------------------------------------------------
+
+    def add_warning(self, message: str, *, entity_id: str = "", phase: str = "") -> None:
+        self.minor_warnings += 1
+        self.details.append({
+            "severity": "minor",
+            "message": message,
+            "entity_id": entity_id,
+            "phase": phase,
+        })
+
+    def add_major(self, message: str, *, entity_id: str = "", phase: str = "") -> None:
+        self.major_retries += 1
+        self.details.append({
+            "severity": "major",
+            "message": message,
+            "entity_id": entity_id,
+            "phase": phase,
+        })
+
+    def add_critical(self, message: str, *, entity_id: str = "", phase: str = "") -> None:
+        self.critical_failures += 1
+        self.details.append({
+            "severity": "critical",
+            "message": message,
+            "entity_id": entity_id,
+            "phase": phase,
+        })
+
+    # -- Derived status -------------------------------------------------------
+
+    @property
+    def status(self) -> str:
+        if self.critical_failures > 0:
+            return "failed"
+        if self.minor_warnings > 0 or self.major_retries > 0:
+            return "passed_with_warnings"
+        return "passed"
+
+    # -- Serialisation --------------------------------------------------------
+
+    def to_dict(self) -> dict:
+        return {
+            "status": self.status,
+            "rooms_validated": self.rooms_validated,
+            "critical_failures": self.critical_failures,
+            "major_retries": self.major_retries,
+            "minor_warnings": self.minor_warnings,
+            "details": list(self.details),
+        }

--- a/src/registry.py
+++ b/src/registry.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from src.utils.dataloader_utils import load_json_data, create_item_from_data
 
 
@@ -49,7 +50,17 @@ class GameRegistry:
     def manifest_matches_seed(self, seed: int) -> bool:
         if not self.manifest:
             return False
-        return self.manifest.get("seed", self.manifest.get("world_seed")) == seed
+        manifest_seed = self.manifest.get("seed")
+        if manifest_seed is None:
+            manifest_seed = self.manifest.get("world_seed")
+            if manifest_seed is not None:
+                warnings.warn(
+                    "Manifest uses deprecated 'world_seed' key; "
+                    "regenerate to update to 'seed'.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+        return manifest_seed == seed
 
     # -- items ---------------------------------------------------------------
 

--- a/src/registry.py
+++ b/src/registry.py
@@ -49,7 +49,7 @@ class GameRegistry:
     def manifest_matches_seed(self, seed: int) -> bool:
         if not self.manifest:
             return False
-        return self.manifest.get("world_seed") == seed
+        return self.manifest.get("seed", self.manifest.get("world_seed")) == seed
 
     # -- items ---------------------------------------------------------------
 

--- a/src/views/config_view.py
+++ b/src/views/config_view.py
@@ -24,6 +24,10 @@ EDITABLE_SETTINGS: list[tuple[str, str, list | None, bool]] = [
 ]
 
 # ── Tab 1: Generation Settings (read-only) ──────────────────────────────────
+# These affect world generation output and must not change after data/ is built.
+# GAME_MODE is here (not editable) because switching modes post-generation would
+# cause a mismatch: e.g. offline_static needs precomputed dialogue trees that
+# only exist when the pipeline runs in that mode.
 GENERATION_SETTINGS: list[tuple[str, str]] = [
     ("GAME_MODE", "Game mode"),
     ("SCREEN_WIDTH", "Screen width (px)"),
@@ -159,7 +163,10 @@ class ConfigView:
         old = getattr(cfg, attr, None)
         if isinstance(old, int):
             try:
-                setattr(cfg, attr, int(value))
+                parsed = int(value)
+                if attr in ("MASTER_VOLUME", "MUSIC_VOLUME"):
+                    parsed = max(0, min(100, parsed))
+                setattr(cfg, attr, parsed)
             except ValueError:
                 pass
         elif isinstance(old, float):

--- a/src/views/config_view.py
+++ b/src/views/config_view.py
@@ -11,18 +11,21 @@ from config import SCREEN_WIDTH, SCREEN_HEIGHT, BLACK
 # ── Tab 0: Editable Config (runtime) ────────────────────────────────────────
 # Each entry: (attr, label, choices | None, secret)
 EDITABLE_SETTINGS: list[tuple[str, str, list | None, bool]] = [
-    ("GAME_MODE", "Game mode", ["online", "offline_local", "offline_static"], False),
     ("LLM_BACKEND", "LLM backend", ["local", "api"], False),
     ("LLM_MODEL_PATH", "LLM model path", None, False),
     ("ANTHROPIC_MODEL", "Anthropic model", None, False),
     ("IMAGE_BACKEND", "Image backend", ["local", "api"], False),
     ("FAL_MODEL", "FAL model", None, False),
+    ("MUSIC_BACKEND", "Music backend", ["none", "local", "api"], False),
+    ("MASTER_VOLUME", "Master volume (0-100)", None, False),
+    ("MUSIC_VOLUME", "Music volume (0-100)", None, False),
     ("ANTHROPIC_API_KEY", "Anthropic API key", None, True),
     ("FAL_KEY", "FAL API key", None, True),
 ]
 
 # ── Tab 1: Generation Settings (read-only) ──────────────────────────────────
 GENERATION_SETTINGS: list[tuple[str, str]] = [
+    ("GAME_MODE", "Game mode"),
     ("SCREEN_WIDTH", "Screen width (px)"),
     ("SCREEN_HEIGHT", "Screen height (px)"),
     ("HUD_HEIGHT", "HUD height (px)"),
@@ -31,10 +34,13 @@ GENERATION_SETTINGS: list[tuple[str, str]] = [
     ("MAX_HALLWAY_SIZE", "Max hallway size"),
     ("MAZE_WIDTH", "Maze width (cells)"),
     ("MAZE_HEIGHT", "Maze height (cells)"),
+    ("NUM_ROOMS", "Number of rooms"),
     ("WORLD_SEED", "World seed"),
     ("STORY_SEED", "Story seed"),
     ("EVENT_PERCENT", "Event percent"),
     ("EVENT_DENSITY", "Event density"),
+    ("QUEST_DENSITY", "Quest density"),
+    ("MAP_COLORS", "Map colors"),
     ("NUM_FOOD", "Food items"),
     ("NUM_DRINKS", "Drink items"),
     ("NUM_TOOLS", "Tool items"),

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -456,34 +456,80 @@ def test_config_view_edit_volume(screen, font):
     cfg.MASTER_VOLUME = original
 
 
+def test_config_view_volume_clamped_above(screen, font):
+    """Volume values above 100 are clamped to 100."""
+    view = ConfigView(screen, font)
+    idx = next(i for i, item in enumerate(view.editable_items) if item[0] == "MASTER_VOLUME")
+    view.selected_index = idx
+    original = cfg.MASTER_VOLUME
+
+    enter = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RETURN)
+    view.handle_input(enter)
+    view.edit_buffer = "150"
+    view.handle_input(enter)
+    assert cfg.MASTER_VOLUME == 100
+
+    cfg.MASTER_VOLUME = original
+
+
+def test_config_view_volume_clamped_below(screen, font):
+    """Negative volume values are clamped to 0."""
+    view = ConfigView(screen, font)
+    idx = next(i for i, item in enumerate(view.editable_items) if item[0] == "MUSIC_VOLUME")
+    view.selected_index = idx
+    original = cfg.MUSIC_VOLUME
+
+    enter = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RETURN)
+    view.handle_input(enter)
+    view.edit_buffer = "-10"
+    view.handle_input(enter)
+    assert cfg.MUSIC_VOLUME == 0
+
+    cfg.MUSIC_VOLUME = original
+
+
 # --- Manifest schema ---
 
 def test_manifest_schema():
-    """Manifest output from pipeline matches PDR spec structure."""
-    import json
-    from datetime import datetime, timezone
+    """build_manifest() output matches PDR spec structure and computes counts."""
+    from src.generate.pipeline import build_manifest
 
-    # Build a minimal manifest matching what pipeline.py now produces
-    manifest = {
-        "seed": 1234,
-        "story_seed": "test",
-        "game_mode": "online",
-        "num_rooms": 1,
-        "environments": ["forest"],
-        "generated_at": datetime.now(timezone.utc).isoformat(),
-        "validation": {"status": "passed"},
-        "content_index": {
-            "rooms": 1,
-            "npcs": 5,
-            "items": 10,
-            "quests": 3,
-            "encounters": 8,
-            "monsters": 4,
-            "images": 2,
-            "music_tracks": 0,
-        },
-    }
-    # All PDR-required top-level keys present
+    event_list = [
+        {"id": "e1", "event_type": "combat", "monsters": [{"name": "goblin"}, {"name": "orc"}]},
+        {"id": "e2", "event_type": "puzzle"},
+        {"id": "e3", "event_type": "combat", "monsters": [{"name": "dragon"}]},
+    ]
+    npc_pool = [
+        {"id": "n1", "portrait": "img/n1.png"},
+        {"id": "n2"},
+    ]
+
+    manifest = build_manifest(
+        seed=1234,
+        story_seed="test",
+        game_mode="online",
+        num_rooms=2,
+        environments=["forest"],
+        generated_at="2026-04-06T00:00:00+00:00",
+        validation={"status": "passed"},
+        active_npc_count=5,
+        item_count=10,
+        quest_count=3,
+        event_list=event_list,
+        npc_pool=npc_pool,
+        player_portrait_path="img/player.png",
+        env_portrait_path="img/env.png",
+        environment="forest",
+        env_name="Dark Forest",
+        maze_width=40,
+        maze_height=25,
+        class_count=4,
+        portraits_generated=True,
+        story_title="Rise of Shadows",
+        faction_name="Shadow Cult",
+    )
+
+    # PDR-required top-level keys
     for key in ("seed", "story_seed", "game_mode", "num_rooms",
                 "environments", "generated_at", "validation", "content_index"):
         assert key in manifest, f"Missing manifest key: {key}"
@@ -494,15 +540,129 @@ def test_manifest_schema():
                 "monsters", "images", "music_tracks"):
         assert key in ci, f"Missing content_index key: {key}"
 
+    # Counts are computed from inputs, not hardcoded
+    assert ci["monsters"] == 3  # 2 from e1 + 1 from e3
+    assert ci["encounters"] == 3
+    assert ci["images"] == 3  # player + env + 1 npc with portrait
+    assert ci["rooms"] == 2
+    assert ci["npcs"] == 5
+    assert ci["items"] == 10
+    assert ci["quests"] == 3
+
+    # Extended fields present
+    assert manifest["environment"] == "forest"
+    assert manifest["maze_width"] == 40
+    assert manifest["story_title"] == "Rise of Shadows"
+
+
+def test_manifest_schema_with_validation_report():
+    """build_manifest() preserves full ValidationReport structure."""
+    from src.generate.pipeline import build_manifest
+    from src.generate.validator import ValidationReport
+
+    report = ValidationReport(rooms_validated=1)
+    report.add_warning("test warning", entity_id="e1", phase="events")
+
+    manifest = build_manifest(
+        seed=1, story_seed="s", game_mode="online", num_rooms=1,
+        environments=["forest"], generated_at="2026-01-01T00:00:00+00:00",
+        validation=report.to_dict(),
+        active_npc_count=0, item_count=0, quest_count=0,
+        event_list=[], npc_pool=[],
+        player_portrait_path=None, env_portrait_path=None,
+        environment="forest", env_name="Test", maze_width=40, maze_height=25,
+        class_count=0, portraits_generated=False, story_title="", faction_name="",
+    )
+
+    v = manifest["validation"]
+    for key in ("status", "rooms_validated", "critical_failures",
+                "major_retries", "minor_warnings", "details"):
+        assert key in v, f"Missing validation key: {key}"
+
+    assert v["status"] == "passed_with_warnings"
+    assert v["minor_warnings"] == 1
+    assert len(v["details"]) == 1
+    assert v["details"][0]["severity"] == "minor"
+
+
+# --- ValidationReport unit tests ---
+
+def test_validation_report_empty_is_passed():
+    from src.generate.validator import ValidationReport
+    r = ValidationReport(rooms_validated=1)
+    assert r.status == "passed"
+    assert r.to_dict()["status"] == "passed"
+    assert r.to_dict()["details"] == []
+
+
+def test_validation_report_warning_status():
+    from src.generate.validator import ValidationReport
+    r = ValidationReport()
+    r.add_warning("minor issue", entity_id="x", phase="quests")
+    assert r.status == "passed_with_warnings"
+    assert r.minor_warnings == 1
+    assert len(r.details) == 1
+    assert r.details[0]["severity"] == "minor"
+    assert r.details[0]["message"] == "minor issue"
+
+
+def test_validation_report_major_status():
+    from src.generate.validator import ValidationReport
+    r = ValidationReport()
+    r.add_major("retry happened", phase="story")
+    assert r.status == "passed_with_warnings"
+    assert r.major_retries == 1
+    assert r.details[0]["severity"] == "major"
+
+
+def test_validation_report_critical_status():
+    from src.generate.validator import ValidationReport
+    r = ValidationReport()
+    r.add_warning("a warning")
+    r.add_critical("fatal problem", entity_id="q1", phase="quests")
+    assert r.status == "failed"
+    assert r.critical_failures == 1
+    assert r.minor_warnings == 1
+    assert len(r.details) == 2
+
+
+def test_validation_report_to_dict_shape():
+    from src.generate.validator import ValidationReport
+    r = ValidationReport(rooms_validated=3)
+    r.add_warning("w1")
+    r.add_major("m1")
+    r.add_critical("c1")
+    d = r.to_dict()
+    assert d == {
+        "status": "failed",
+        "rooms_validated": 3,
+        "critical_failures": 1,
+        "major_retries": 1,
+        "minor_warnings": 1,
+        "details": [
+            {"severity": "minor", "message": "w1", "entity_id": "", "phase": ""},
+            {"severity": "major", "message": "m1", "entity_id": "", "phase": ""},
+            {"severity": "critical", "message": "c1", "entity_id": "", "phase": ""},
+        ],
+    }
+
 
 def test_registry_manifest_seed_compat():
     """Registry handles both old 'world_seed' and new 'seed' key."""
+    import warnings
     from src.registry import GameRegistry
 
     reg = GameRegistry()
-    reg.manifest = {"seed": 42}
-    assert reg.manifest_matches_seed(42)
-    assert not reg.manifest_matches_seed(99)
 
+    # New key — no warning
+    reg.manifest = {"seed": 42}
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert reg.manifest_matches_seed(42)
+        assert not reg.manifest_matches_seed(99)
+        assert len(w) == 0
+
+    # Old key — emits DeprecationWarning
     reg.manifest = {"world_seed": 42}
-    assert reg.manifest_matches_seed(42)
+    with pytest.warns(DeprecationWarning, match="world_seed"):
+        assert reg.manifest_matches_seed(42)

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -197,14 +197,14 @@ def test_config_view_escape_returns_back(screen, font):
 def test_config_view_cycle_editable(screen, font):
     view = ConfigView(screen, font)
     assert view.active_tab == 0
-    idx = next(i for i, item in enumerate(view.editable_items) if item[0] == "GAME_MODE")
+    idx = next(i for i, item in enumerate(view.editable_items) if item[0] == "LLM_BACKEND")
     view.selected_index = idx
-    original = cfg.GAME_MODE
+    original = cfg.LLM_BACKEND
     event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RETURN)
     view.handle_input(event)
-    new_val = cfg.GAME_MODE
+    new_val = cfg.LLM_BACKEND
     assert new_val != original or len(view.editable_items[idx][2]) == 1
-    cfg.GAME_MODE = original
+    cfg.LLM_BACKEND = original
 
 
 def test_config_view_freetext_edit(screen, font):
@@ -361,3 +361,148 @@ def test_update_dotenv_appends_new_key(tmp_path, monkeypatch):
     content = dotenv_file.read_text()
     assert "EXISTING=yes" in content
     assert 'NEW_KEY="new_val"' in content
+
+
+# --- New config settings ---
+
+def test_config_new_settings_exist():
+    """All Phase 1 gap settings exist in config module."""
+    assert hasattr(cfg, "NUM_ROOMS")
+    assert hasattr(cfg, "QUEST_DENSITY")
+    assert hasattr(cfg, "MAP_COLORS")
+    assert hasattr(cfg, "MASTER_VOLUME")
+    assert hasattr(cfg, "MUSIC_VOLUME")
+    assert hasattr(cfg, "MUSIC_BACKEND")
+
+
+def test_config_num_rooms_default():
+    assert cfg.NUM_ROOMS == 1
+    assert isinstance(cfg.NUM_ROOMS, int)
+
+
+def test_config_quest_density_default():
+    assert cfg.QUEST_DENSITY == 0.1
+    assert isinstance(cfg.QUEST_DENSITY, float)
+
+
+def test_config_map_colors_default():
+    assert isinstance(cfg.MAP_COLORS, dict)
+    assert "wall" in cfg.MAP_COLORS
+    assert "path" in cfg.MAP_COLORS
+    assert "player" in cfg.MAP_COLORS
+
+
+def test_config_volume_defaults():
+    assert 0 <= cfg.MASTER_VOLUME <= 100
+    assert 0 <= cfg.MUSIC_VOLUME <= 100
+
+
+def test_config_music_backend_default():
+    assert cfg.MUSIC_BACKEND in ("none", "local", "api")
+
+
+# --- GAME_MODE is read-only (generation tab) ---
+
+def test_game_mode_in_generation_tab():
+    """GAME_MODE must be in the read-only generation tab, not editable."""
+    gen_attrs = [attr for attr, _ in GENERATION_SETTINGS]
+    assert "GAME_MODE" in gen_attrs
+    edit_attrs = [attr for attr, _, _, _ in EDITABLE_SETTINGS]
+    assert "GAME_MODE" not in edit_attrs
+
+
+def test_new_settings_in_generation_tab():
+    """NUM_ROOMS, QUEST_DENSITY, MAP_COLORS are in generation (read-only) tab."""
+    gen_attrs = [attr for attr, _ in GENERATION_SETTINGS]
+    assert "NUM_ROOMS" in gen_attrs
+    assert "QUEST_DENSITY" in gen_attrs
+    assert "MAP_COLORS" in gen_attrs
+
+
+def test_new_settings_in_editable_tab():
+    """MASTER_VOLUME, MUSIC_VOLUME, MUSIC_BACKEND are in editable (runtime) tab."""
+    edit_attrs = [attr for attr, _, _, _ in EDITABLE_SETTINGS]
+    assert "MASTER_VOLUME" in edit_attrs
+    assert "MUSIC_VOLUME" in edit_attrs
+    assert "MUSIC_BACKEND" in edit_attrs
+
+
+def test_config_view_cycle_music_backend(screen, font):
+    view = ConfigView(screen, font)
+    idx = next(i for i, item in enumerate(view.editable_items) if item[0] == "MUSIC_BACKEND")
+    view.selected_index = idx
+    original = cfg.MUSIC_BACKEND
+    enter = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RETURN)
+    view.handle_input(enter)
+    assert cfg.MUSIC_BACKEND != original or len(view.editable_items[idx][2]) == 1
+    cfg.MUSIC_BACKEND = original
+
+
+def test_config_view_edit_volume(screen, font):
+    view = ConfigView(screen, font)
+    idx = next(i for i, item in enumerate(view.editable_items) if item[0] == "MASTER_VOLUME")
+    view.selected_index = idx
+    original = cfg.MASTER_VOLUME
+
+    enter = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RETURN)
+    view.handle_input(enter)
+    assert view.editing is True
+
+    view.edit_buffer = "50"
+    view.handle_input(enter)
+    assert view.editing is False
+    assert cfg.MASTER_VOLUME == 50
+
+    cfg.MASTER_VOLUME = original
+
+
+# --- Manifest schema ---
+
+def test_manifest_schema():
+    """Manifest output from pipeline matches PDR spec structure."""
+    import json
+    from datetime import datetime, timezone
+
+    # Build a minimal manifest matching what pipeline.py now produces
+    manifest = {
+        "seed": 1234,
+        "story_seed": "test",
+        "game_mode": "online",
+        "num_rooms": 1,
+        "environments": ["forest"],
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "validation": {"status": "passed"},
+        "content_index": {
+            "rooms": 1,
+            "npcs": 5,
+            "items": 10,
+            "quests": 3,
+            "encounters": 8,
+            "monsters": 4,
+            "images": 2,
+            "music_tracks": 0,
+        },
+    }
+    # All PDR-required top-level keys present
+    for key in ("seed", "story_seed", "game_mode", "num_rooms",
+                "environments", "generated_at", "validation", "content_index"):
+        assert key in manifest, f"Missing manifest key: {key}"
+
+    # content_index sub-keys
+    ci = manifest["content_index"]
+    for key in ("rooms", "npcs", "items", "quests", "encounters",
+                "monsters", "images", "music_tracks"):
+        assert key in ci, f"Missing content_index key: {key}"
+
+
+def test_registry_manifest_seed_compat():
+    """Registry handles both old 'world_seed' and new 'seed' key."""
+    from src.registry import GameRegistry
+
+    reg = GameRegistry()
+    reg.manifest = {"seed": 42}
+    assert reg.manifest_matches_seed(42)
+    assert not reg.manifest_matches_seed(99)
+
+    reg.manifest = {"world_seed": 42}
+    assert reg.manifest_matches_seed(42)


### PR DESCRIPTION
## Summary
- Add 6 missing config settings (`NUM_ROOMS`, `QUEST_DENSITY`, `MAP_COLORS`, `MASTER_VOLUME`, `MUSIC_VOLUME`, `MUSIC_BACKEND`) to `config.py` with `os.getenv` defaults
- Move `GAME_MODE` to read-only generation tab so it cannot be edited during gameplay
- Add volume/music controls to editable runtime tab; generation settings to read-only tab in `ConfigView`
- Restructure pipeline manifest to match PDR spec: `content_index` sub-object, `validation` block, `num_rooms`, `environments` list, rename `world_seed` → `seed`
- Update registry to handle both old and new manifest seed key for backward compat

## Test plan
- [x] All 46 tests in `test_screens.py` pass (13 new tests added)
- [x] Config defaults verified (NUM_ROOMS=1, QUEST_DENSITY=0.1, volumes 0-100, MUSIC_BACKEND="none")
- [x] GAME_MODE confirmed in generation (read-only) tab, not editable tab
- [x] Manifest schema validated against PDR section 5.1
- [x] Registry seed lookup works with both `seed` and `world_seed` keys