### PR TITLE
Phase 9: Survival rebalance & remaining screens

### DIFF
--- a/main.py
+++ b/main.py
@@ -424,9 +424,15 @@ def main():
         if result == "victory":
             elapsed = time.time() - gameplay_start_time
             total_time = accumulated_play_time + elapsed
+            monsters_killed = sum(
+                1 for e in game_controller.events.values()
+                if getattr(e, 'resolved', False)
+            )
             victory_view = VictoryView(
                 screen, font, game_controller.player,
                 time_played=total_time,
+                monsters_killed=monsters_killed,
+                money_earned=game_controller.player.money,
             )
             screen_ctrl.push(ScreenState.VICTORY)
             return None

--- a/main.py
+++ b/main.py
@@ -30,6 +30,10 @@ from src.views.class_select_view import ClassSelectView
 from src.views.room_intro_view import RoomIntroView
 from src.views.player_menu_view import PlayerMenuView
 from src.views.load_game_view import LoadGameView
+from src.views.pause_view import PauseView
+from src.views.gameover_view import GameOverView
+from src.views.victory_view import VictoryView
+from src.views.menu_view import MenuView
 from src.systems import save_manager
 
 logger = logging.getLogger(__name__)
@@ -274,6 +278,10 @@ def main():
     accumulated_play_time = 0.0
     # Track where load was opened from: "start" or "gameplay"
     load_source = "start"
+    pause_view = None
+    gameover_view = None
+    victory_view = None
+    menu_view = None
 
     def _handle_start() -> str | None:
         nonlocal class_select_view, load_game_view, load_source
@@ -376,6 +384,7 @@ def main():
     def _handle_gameplay() -> str | None:
         nonlocal game_controller, gameplay_start_time, player_menu_view
         nonlocal load_game_view, load_source
+        nonlocal pause_view, gameover_view, victory_view, menu_view
 
         if game_controller is None:
             game_controller = setup_game(screen, font, player_name, selected_class)
@@ -393,14 +402,60 @@ def main():
             screen_ctrl.push(ScreenState.PLAYER_MENU)
             return None
 
+        if result == "open_pause":
+            can_save = not game_controller.has_active_overlay
+            pause_view = PauseView(screen, font, can_save=can_save)
+            screen_ctrl.push(ScreenState.PAUSE)
+            return None
+
+        if result == "open_full_menu":
+            menu_view = MenuView(screen, font, game_controller.player)
+            screen_ctrl.push(ScreenState.PLAYER_MENU)
+            return None
+
+        if result == "game_over":
+            gameover_view = GameOverView(
+                screen, font, game_controller.player,
+                has_saves=_cached_has_saves,
+            )
+            screen_ctrl.push(ScreenState.GAME_OVER)
+            return None
+
+        if result == "victory":
+            elapsed = time.time() - gameplay_start_time
+            total_time = accumulated_play_time + elapsed
+            victory_view = VictoryView(
+                screen, font, game_controller.player,
+                time_played=total_time,
+            )
+            screen_ctrl.push(ScreenState.VICTORY)
+            return None
+
         # Game loop ended (window closed)
         return "quit"
 
     def _handle_player_menu() -> str | None:
-        nonlocal game_controller, player_menu_view
+        nonlocal game_controller, player_menu_view, menu_view
         nonlocal load_game_view, load_source, gameplay_start_time
         nonlocal accumulated_play_time
 
+        # Full tabbed menu mode
+        if menu_view is not None:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    return "quit"
+                if event.type == pygame.KEYDOWN:
+                    action = menu_view.handle_input(event)
+                    if action == "close":
+                        menu_view = None
+                        screen_ctrl.pop()
+                        return None
+            menu_view.draw()
+            pygame.display.flip()
+            clock.tick(60)
+            return None
+
+        # Save/load menu mode
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 return "quit"
@@ -434,6 +489,89 @@ def main():
             current_time = pygame.time.get_ticks()
             game_controller.draw(current_time)
         player_menu_view.draw()
+        pygame.display.flip()
+        clock.tick(60)
+        return None
+
+    def _handle_pause() -> str | None:
+        nonlocal pause_view, game_controller, gameplay_start_time
+        nonlocal accumulated_play_time, _cached_has_saves
+
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                return "quit"
+            if event.type == pygame.KEYDOWN:
+                action = pause_view.handle_input(event)
+                if action == "resume":
+                    screen_ctrl.pop()
+                    return None
+                if action == "save":
+                    elapsed = time.time() - gameplay_start_time
+                    total_time = accumulated_play_time + elapsed
+                    try:
+                        save_manager.save_game(
+                            game_controller, WORLD_SEED, total_time,
+                        )
+                        _cached_has_saves = True
+                        pause_view.set_status("Game saved!")
+                    except Exception as e:
+                        pause_view.set_status(f"Save failed: {e}", is_error=True)
+                    return None
+                if action == "quit_to_start":
+                    game_controller = None
+                    screen_ctrl.reset_to(ScreenState.START)
+                    return None
+
+        # Draw the game underneath, then the pause overlay
+        if game_controller:
+            current_time = pygame.time.get_ticks()
+            game_controller.draw(current_time)
+        pause_view.draw()
+        pygame.display.flip()
+        clock.tick(60)
+        return None
+
+    def _handle_game_over() -> str | None:
+        nonlocal gameover_view, game_controller
+        nonlocal load_game_view, load_source
+
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                return "quit"
+            if event.type == pygame.KEYDOWN:
+                action = gameover_view.handle_input(event)
+                if action == "load":
+                    saves = save_manager.list_saves()
+                    load_game_view = LoadGameView(screen, font, saves)
+                    load_source = "start"
+                    screen_ctrl.replace(ScreenState.LOAD_GAME)
+                    return None
+                if action == "quit_to_start":
+                    game_controller = None
+                    screen_ctrl.reset_to(ScreenState.START)
+                    return None
+
+        gameover_view.draw()
+        pygame.display.flip()
+        clock.tick(60)
+        return None
+
+    def _handle_victory() -> str | None:
+        nonlocal victory_view, game_controller
+
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                return "quit"
+            if event.type == pygame.KEYDOWN:
+                action = victory_view.handle_input(event)
+                if action == "new_game":
+                    game_controller = None
+                    screen_ctrl.reset_to(ScreenState.START)
+                    return None
+                if action == "quit":
+                    return "quit"
+
+        victory_view.draw()
         pygame.display.flip()
         clock.tick(60)
         return None
@@ -489,6 +627,9 @@ def main():
         ScreenState.GAMEPLAY: _handle_gameplay,
         ScreenState.PLAYER_MENU: _handle_player_menu,
         ScreenState.LOAD_GAME: _handle_load_game,
+        ScreenState.PAUSE: _handle_pause,
+        ScreenState.GAME_OVER: _handle_game_over,
+        ScreenState.VICTORY: _handle_victory,
     }
 
     running = True

--- a/src/controllers/game_controller.py
+++ b/src/controllers/game_controller.py
@@ -7,6 +7,7 @@ from src.models.items import EscortItem
 from src.models.follower import Follower
 from src.registry import registry
 from src.utils.conversation_utils import has_dialogue_choices
+from src.systems.survival import SurvivalSystem
 
 
 class GameController:
@@ -27,6 +28,9 @@ class GameController:
 
         # Check for kill quests already cleared at startup
         self._check_kill_quests_already_cleared()
+
+        # Survival system
+        self.survival = SurvivalSystem()
 
         # UI / State variables
         self.inventory_active = False
@@ -49,7 +53,7 @@ class GameController:
 
         # Player menu / save-load state
         self.player_menu_active = False
-        self.pending_action = None  # Set to "save", "load", "quit" to signal main loop
+        self.pending_action = None  # Set to "save", "load", "quit", "open_pause", "open_menu" to signal main loop
 
         self.game_view = GameView(screen, font, dialogue_box)
 
@@ -223,7 +227,11 @@ class GameController:
                 dx, dy = 0, -1
             elif event.key == pygame.K_DOWN:
                 dx, dy = 0, 1
-            self.player.move(dx=dx, dy=dy, maze=self.maze)
+            self.player.move(dx=dx, dy=dy, maze=self.maze, survival_system=self.survival)
+            # Check for game over from starvation
+            if self.player.health <= 0:
+                self.pending_action = "game_over"
+                return
             self.after_move_check()
             return
 
@@ -271,8 +279,13 @@ class GameController:
             if self.quest_log_active:
                 self.quest_log_active = False
                 return
-            # Esc also opens menu in normal gameplay
-            self.pending_action = "open_menu"
+            # Esc opens pause menu in normal gameplay
+            self.pending_action = "open_pause"
+            return
+
+        # M key opens full tabbed menu
+        if event.key == pygame.K_m:
+            self.pending_action = "open_full_menu"
             return
 
     def _handle_event_input(self, event):
@@ -546,6 +559,10 @@ class GameController:
                     self.player.complete_quest(qid)
 
         self.dialogue_box.end_event()
+
+        # Check for player death after combat
+        if self.player.health <= 0:
+            self.pending_action = "game_over"
 
     def _handle_npc_interaction(self, npc):
         """Start dialogue with an NPC, handling quest offers and completions."""

--- a/src/controllers/game_controller.py
+++ b/src/controllers/game_controller.py
@@ -53,7 +53,7 @@ class GameController:
 
         # Player menu / save-load state
         self.player_menu_active = False
-        self.pending_action = None  # Set to "save", "load", "quit", "open_pause", "open_menu" to signal main loop
+        self.pending_action = None  # Set to "save", "load", "quit", "open_pause", "open_full_menu", "game_over", "victory" to signal main loop
 
         self.game_view = GameView(screen, font, dialogue_box)
 

--- a/src/models/player.py
+++ b/src/models/player.py
@@ -195,16 +195,20 @@ class PlayerCharacter(BaseModel):
         }
         self.money = STARTING_MONEY
         
-    def move(self, dx: int, dy: int, maze):
+    def move(self, dx: int, dy: int, maze, survival_system=None):
         new_x = self.x + dx
         new_y = self.y + dy
-        
+
         if not maze.is_wall(new_x, new_y):
             self.x = new_x
             self.y = new_y
-            self.hunger = max(0, self.hunger - 1)
-            self.thirst = max(0, self.thirst -1)
-            self.apply_hunger_thirst_effects()
+            if survival_system is not None:
+                survival_system.on_move(self)
+            else:
+                # Legacy fallback
+                self.hunger = max(0, self.hunger - 1)
+                self.thirst = max(0, self.thirst - 1)
+                self.apply_hunger_thirst_effects()
 
     def add_to_inventory(self, item):
         """Add an item to the player's inventory."""

--- a/src/systems/survival.py
+++ b/src/systems/survival.py
@@ -1,1 +1,126 @@
-"""Hunger/thirst/HP drain, rest, recovery system — stub for later phases."""
+"""Hunger/thirst/HP drain, recovery system.
+
+Drain rates are ~1/3 of the original (which was -1 per step).
+CON modifier reduces drain per step (minimum 1 drain).
+No drain while stationary (talking to NPCs, menus).
+Thresholds: warning < 30, penalty < 15, critical = 0.
+Starvation/dehydration: at 0, slow HP drain (1 per 5 steps).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.models.player import PlayerCharacter
+
+# --- Thresholds ---
+THRESHOLD_WARNING = 30
+THRESHOLD_PENALTY = 15
+THRESHOLD_CRITICAL = 0
+
+# --- Drain tuning ---
+BASE_HUNGER_DRAIN = 1       # Applied every DRAIN_INTERVAL steps
+BASE_THIRST_DRAIN = 1       # Applied every DRAIN_INTERVAL steps
+DRAIN_INTERVAL = 3          # Drain happens once every N movement steps (~1/3 rate)
+
+# --- Starvation / dehydration ---
+STARVATION_HP_DRAIN = 1
+STARVATION_INTERVAL = 5     # HP lost once every N steps at 0 hunger or thirst
+
+# --- Penalty multipliers ---
+SPEED_PENALTY_FACTOR = 0.7  # Speed multiplier when hunger or thirst < 15
+
+
+class SurvivalSystem:
+    """Manages hunger/thirst drain and HP penalties for a player."""
+
+    def __init__(self):
+        self._step_counter: int = 0
+        self._starvation_counter: int = 0
+
+    def on_move(self, player: PlayerCharacter) -> list[str]:
+        """Called once per movement step. Returns a list of warning/effect messages."""
+        messages: list[str] = []
+
+        self._step_counter += 1
+
+        # --- Drain (every DRAIN_INTERVAL steps) ---
+        if self._step_counter >= DRAIN_INTERVAL:
+            self._step_counter = 0
+            con_mod = player.get_stat_modifier("CON")
+            hunger_drain = max(1, BASE_HUNGER_DRAIN - con_mod)
+            thirst_drain = max(1, BASE_THIRST_DRAIN - con_mod)
+            player.hunger = max(0, player.hunger - hunger_drain)
+            player.thirst = max(0, player.thirst - thirst_drain)
+
+        # --- Starvation / dehydration HP drain ---
+        starving = player.hunger <= THRESHOLD_CRITICAL
+        dehydrated = player.thirst <= THRESHOLD_CRITICAL
+        if starving or dehydrated:
+            self._starvation_counter += 1
+            if self._starvation_counter >= STARVATION_INTERVAL:
+                self._starvation_counter = 0
+                player.health = max(0, player.health - STARVATION_HP_DRAIN)
+                if starving and dehydrated:
+                    messages.append("You are starving and dehydrated! Losing health.")
+                elif starving:
+                    messages.append("You are starving! Losing health.")
+                else:
+                    messages.append("You are dehydrated! Losing health.")
+        else:
+            self._starvation_counter = 0
+
+        # --- Threshold warnings (once per drain tick) ---
+        if 0 < player.hunger <= THRESHOLD_WARNING and player.hunger > THRESHOLD_PENALTY:
+            messages.append("You are getting hungry.")
+        if 0 < player.thirst <= THRESHOLD_WARNING and player.thirst > THRESHOLD_PENALTY:
+            messages.append("You are getting thirsty.")
+
+        # --- Penalty effects ---
+        self._apply_penalties(player)
+
+        return messages
+
+    def _apply_penalties(self, player: PlayerCharacter):
+        """Apply speed and capability penalties based on survival thresholds."""
+        hunger_penalty = player.hunger <= THRESHOLD_PENALTY and player.hunger > THRESHOLD_CRITICAL
+        thirst_penalty = player.thirst <= THRESHOLD_PENALTY and player.thirst > THRESHOLD_CRITICAL
+
+        if hunger_penalty or thirst_penalty:
+            player.speed = player.max_speed * SPEED_PENALTY_FACTOR
+        elif player.hunger > THRESHOLD_PENALTY and player.thirst > THRESHOLD_PENALTY:
+            player.speed = player.max_speed
+
+    def can_cast(self, player: PlayerCharacter) -> bool:
+        """Returns False if player is at critical hunger or thirst (can't cast)."""
+        return player.hunger > THRESHOLD_CRITICAL and player.thirst > THRESHOLD_CRITICAL
+
+    def get_spell_effectiveness(self, player: PlayerCharacter) -> float:
+        """Returns spell damage/heal multiplier based on survival state.
+
+        Full effectiveness above penalty threshold.
+        Reduced (0.5x) when in penalty range.
+        Zero when critical.
+        """
+        if player.hunger <= THRESHOLD_CRITICAL or player.thirst <= THRESHOLD_CRITICAL:
+            return 0.0
+        if player.hunger <= THRESHOLD_PENALTY or player.thirst <= THRESHOLD_PENALTY:
+            return 0.5
+        return 1.0
+
+    def get_status(self, player: PlayerCharacter) -> dict:
+        """Return current survival status for UI display."""
+        return {
+            "hunger": player.hunger,
+            "thirst": player.thirst,
+            "hunger_max": player.max_hunger,
+            "thirst_max": player.max_thirst,
+            "hunger_warning": player.hunger <= THRESHOLD_WARNING,
+            "thirst_warning": player.thirst <= THRESHOLD_WARNING,
+            "hunger_penalty": player.hunger <= THRESHOLD_PENALTY,
+            "thirst_penalty": player.thirst <= THRESHOLD_PENALTY,
+            "starving": player.hunger <= THRESHOLD_CRITICAL,
+            "dehydrated": player.thirst <= THRESHOLD_CRITICAL,
+            "can_cast": self.can_cast(player),
+        }

--- a/src/systems/survival.py
+++ b/src/systems/survival.py
@@ -84,8 +84,8 @@ class SurvivalSystem:
 
     def _apply_penalties(self, player: PlayerCharacter):
         """Apply speed and capability penalties based on survival thresholds."""
-        hunger_penalty = player.hunger <= THRESHOLD_PENALTY and player.hunger > THRESHOLD_CRITICAL
-        thirst_penalty = player.thirst <= THRESHOLD_PENALTY and player.thirst > THRESHOLD_CRITICAL
+        hunger_penalty = player.hunger <= THRESHOLD_PENALTY
+        thirst_penalty = player.thirst <= THRESHOLD_PENALTY
 
         if hunger_penalty or thirst_penalty:
             player.speed = player.max_speed * SPEED_PENALTY_FACTOR

--- a/src/views/gameover_view.py
+++ b/src/views/gameover_view.py
@@ -1,1 +1,80 @@
-"""Game over screen view — stub for later phases."""
+"""Game over screen — displays death message, brief stats, and options."""
+
+import pygame
+from config import SCREEN_WIDTH, SCREEN_HEIGHT, BLACK
+
+TITLE_COLOR = (200, 50, 50)
+TEXT_COLOR = (180, 180, 180)
+SELECTED_COLOR = (255, 255, 100)
+UNSELECTED_COLOR = (180, 180, 180)
+
+MENU_ITEMS = ["Load Game", "Quit to Start"]
+
+
+class GameOverView:
+    """Game Over screen with brief stats summary and load/quit options."""
+
+    def __init__(self, screen, font, player, has_saves=False):
+        self.screen = screen
+        self.font = font
+        self.title_font = pygame.font.Font(None, 64)
+        self.small_font = pygame.font.Font(None, 24)
+        self.player = player
+        self.has_saves = has_saves
+        self.selected_index = 0
+
+    def draw(self):
+        self.screen.fill(BLACK)
+
+        # Title
+        title = self.title_font.render("GAME OVER", True, TITLE_COLOR)
+        self.screen.blit(title, ((SCREEN_WIDTH - title.get_width()) // 2, 100))
+
+        # Death message
+        name = self.player.name
+        cls_name = self.player.player_class.name if self.player.player_class else "Adventurer"
+        msg = self.font.render(f"{name} the {cls_name} has fallen.", True, TEXT_COLOR)
+        self.screen.blit(msg, ((SCREEN_WIDTH - msg.get_width()) // 2, 180))
+
+        # Brief stats
+        stats = [
+            f"Level: {self.player.level}",
+            f"Quests Completed: {len(self.player.completed_quests)}",
+            f"Quests Failed: {len(self.player.failed_quests)}",
+        ]
+        y = 240
+        for line in stats:
+            surf = self.small_font.render(line, True, TEXT_COLOR)
+            self.screen.blit(surf, ((SCREEN_WIDTH - surf.get_width()) // 2, y))
+            y += 28
+
+        # Menu options
+        y = SCREEN_HEIGHT // 2 + 60
+        for i, item in enumerate(MENU_ITEMS):
+            disabled = (item == "Load Game" and not self.has_saves)
+            if disabled:
+                color = (80, 80, 80)
+            elif i == self.selected_index:
+                color = SELECTED_COLOR
+            else:
+                color = UNSELECTED_COLOR
+            prefix = "> " if i == self.selected_index else "  "
+            surf = self.font.render(f"{prefix}{item}", True, color)
+            self.screen.blit(surf, ((SCREEN_WIDTH - surf.get_width()) // 2, y))
+            y += 40
+
+    def handle_input(self, event) -> str | None:
+        """Returns 'load' or 'quit_to_start', or None."""
+        if event.key == pygame.K_UP:
+            self.selected_index = (self.selected_index - 1) % len(MENU_ITEMS)
+        elif event.key == pygame.K_DOWN:
+            self.selected_index = (self.selected_index + 1) % len(MENU_ITEMS)
+        elif event.key == pygame.K_RETURN:
+            selected = MENU_ITEMS[self.selected_index]
+            if selected == "Load Game" and not self.has_saves:
+                return None
+            if selected == "Load Game":
+                return "load"
+            if selected == "Quit to Start":
+                return "quit_to_start"
+        return None

--- a/src/views/menu_view.py
+++ b/src/views/menu_view.py
@@ -1,1 +1,387 @@
-"""Tabbed player menu view — stub for later phases."""
+"""Tabbed player menu view — Inventory, Stats, Spells/Abilities tabs."""
+
+import pygame
+from config import SCREEN_WIDTH, SCREEN_HEIGHT, BLACK
+
+TITLE_COLOR = (220, 180, 60)
+TAB_ACTIVE_COLOR = (255, 255, 100)
+TAB_INACTIVE_COLOR = (120, 120, 120)
+TEXT_COLOR = (200, 200, 200)
+HIGHLIGHT_COLOR = (255, 255, 150)
+SELECTED_COLOR = (255, 80, 80)
+HEADER_COLOR = (180, 160, 80)
+EQUIPPED_COLOR = (100, 255, 100)
+STAT_LABEL_COLOR = (160, 160, 180)
+STAT_VALUE_COLOR = (220, 220, 255)
+
+TABS = ["Inventory", "Stats", "Spells"]
+
+# Item category display order
+CATEGORY_ORDER = ["weapon", "food", "drink", "tool", "scroll", "escort"]
+CATEGORY_LABELS = {
+    "weapon": "Weapons",
+    "food": "Food",
+    "drink": "Drinks",
+    "tool": "Tools",
+    "scroll": "Scrolls",
+    "escort": "Escort",
+}
+
+
+class MenuView:
+    """Full-screen tabbed player menu with Inventory, Stats, and Spells tabs."""
+
+    def __init__(self, screen, font, player):
+        self.screen = screen
+        self.font = font
+        self.small_font = pygame.font.Font(None, 22)
+        self.title_font = pygame.font.Font(None, 40)
+        self.player = player
+        self.active_tab = 0
+        self.selected_index = 0
+        self.scroll_offset = 0
+        self.action_message = ""
+        self.action_message_timer = 0
+
+    def draw(self):
+        self.screen.fill((20, 20, 30))
+
+        # Tab bar
+        self._draw_tabs()
+
+        # Content area
+        if self.active_tab == 0:
+            self._draw_inventory()
+        elif self.active_tab == 1:
+            self._draw_stats()
+        elif self.active_tab == 2:
+            self._draw_spells()
+
+        # Action message
+        if self.action_message and self.action_message_timer > 0:
+            msg = self.font.render(self.action_message, True, (100, 255, 100))
+            self.screen.blit(msg, ((SCREEN_WIDTH - msg.get_width()) // 2, SCREEN_HEIGHT - 30))
+            self.action_message_timer -= 1
+
+        # Controls hint
+        hint = "Tab: Switch Tab  |  Esc: Close"
+        hint_surf = self.small_font.render(hint, True, (100, 100, 100))
+        self.screen.blit(hint_surf, (10, SCREEN_HEIGHT - 20))
+
+    def _draw_tabs(self):
+        tab_width = SCREEN_WIDTH // len(TABS)
+        for i, tab_name in enumerate(TABS):
+            x = i * tab_width
+            active = i == self.active_tab
+            bg_color = (50, 50, 70) if active else (30, 30, 40)
+            pygame.draw.rect(self.screen, bg_color, (x, 0, tab_width, 36))
+            pygame.draw.line(self.screen, (80, 80, 100), (x, 0), (x, 36))
+
+            color = TAB_ACTIVE_COLOR if active else TAB_INACTIVE_COLOR
+            label = self.font.render(tab_name, True, color)
+            self.screen.blit(label, (x + (tab_width - label.get_width()) // 2, 6))
+
+        pygame.draw.line(self.screen, (80, 80, 100), (0, 36), (SCREEN_WIDTH, 36))
+
+    # --- Inventory Tab ---
+
+    def _draw_inventory(self):
+        y = 50
+        # Gold
+        gold = self.font.render(f"Gold: {self.player.money}", True, (220, 190, 60))
+        self.screen.blit(gold, (SCREEN_WIDTH - gold.get_width() - 20, y))
+
+        items = list(self.player.inventory.values())
+        if not items:
+            empty = self.font.render("Your inventory is empty.", True, TEXT_COLOR)
+            self.screen.blit(empty, (40, y + 40))
+            return
+
+        # Group items by category
+        grouped: dict[str, list] = {}
+        for item in items:
+            cat = item.category.lower()
+            grouped.setdefault(cat, []).append(item)
+
+        flat_items = []  # For selection indexing
+        for cat in CATEGORY_ORDER:
+            if cat in grouped:
+                flat_items.append(("header", cat))
+                for item in grouped[cat]:
+                    flat_items.append(("item", item))
+        # Any remaining categories
+        for cat, cat_items in grouped.items():
+            if cat not in CATEGORY_ORDER:
+                flat_items.append(("header", cat))
+                for item in cat_items:
+                    flat_items.append(("item", item))
+
+        # Count only items (not headers) for selection
+        item_indices = [i for i, (kind, _) in enumerate(flat_items) if kind == "item"]
+        if item_indices and self.selected_index >= len(item_indices):
+            self.selected_index = len(item_indices) - 1
+
+        y = 50
+        item_counter = 0
+        for kind, entry in flat_items:
+            if y > SCREEN_HEIGHT - 80:
+                more = self.small_font.render("... (scroll down)", True, (120, 120, 120))
+                self.screen.blit(more, (40, y))
+                break
+
+            if kind == "header":
+                y += 8
+                label = CATEGORY_LABELS.get(entry, entry.title())
+                header = self.font.render(f"-- {label} --", True, HEADER_COLOR)
+                self.screen.blit(header, (40, y))
+                y += 28
+            else:
+                item = entry
+                is_selected = item_counter == self.selected_index
+                is_equipped = self.player.equipped_weapon == item.name
+
+                prefix = "> " if is_selected else "  "
+                equip_tag = "[E] " if is_equipped else ""
+                color = SELECTED_COLOR if is_selected else (EQUIPPED_COLOR if is_equipped else TEXT_COLOR)
+
+                name_text = f"{prefix}{equip_tag}{item.quantity}x {item.name}"
+                name_surf = self.small_font.render(name_text, True, color)
+                self.screen.blit(name_surf, (40, y))
+
+                # Brief effect
+                effect_parts = []
+                stats = item.item_stats
+                if stats.nutrition_value:
+                    effect_parts.append(f"+{stats.nutrition_value} food")
+                if stats.hydration_value:
+                    effect_parts.append(f"+{stats.hydration_value} water")
+                if stats.health_value:
+                    effect_parts.append(f"+{stats.health_value} HP")
+                if stats.attack_dice:
+                    effect_parts.append(f"Dmg:{stats.attack_dice}")
+                if effect_parts:
+                    effect = "  ".join(effect_parts)
+                    effect_surf = self.small_font.render(effect, True, (120, 120, 140))
+                    self.screen.blit(effect_surf, (400, y))
+
+                y += 22
+                item_counter += 1
+
+        # Controls
+        ctrl = "Up/Down: Select  |  Enter/U: Use  |  E: Equip  |  D: Drop"
+        ctrl_surf = self.small_font.render(ctrl, True, (100, 100, 100))
+        self.screen.blit(ctrl_surf, (40, SCREEN_HEIGHT - 50))
+
+    # --- Stats Tab ---
+
+    def _draw_stats(self):
+        p = self.player
+        pc = p.player_class
+        y = 50
+        col1 = 40
+        col2 = SCREEN_WIDTH // 2 + 20
+
+        # Character info
+        cls_name = pc.name if pc else "Adventurer"
+        env = pc.environment if pc else "Unknown"
+        self._stat_line(f"{p.name} the {cls_name}", HIGHLIGHT_COLOR, col1, y)
+        y += 28
+        self._stat_line(f"Level {p.level}  |  {env}", TEXT_COLOR, col1, y)
+        y += 36
+
+        # Stat array
+        self._stat_line("-- Attributes --", HEADER_COLOR, col1, y)
+        y += 24
+        if pc:
+            stats_dict = pc.stats.as_dict()
+            for stat_name, val in stats_dict.items():
+                mod = pc.stats.modifier(stat_name)
+                mod_str = f"+{mod}" if mod >= 0 else str(mod)
+                self._stat_pair(stat_name, f"{val} ({mod_str})", col1, y)
+                y += 22
+        y += 10
+
+        # Derived stats
+        self._stat_line("-- Derived Stats --", HEADER_COLOR, col1, y)
+        y += 24
+        ac = p.get_ac()
+        atk_mod = p.get_stat_mod("STR")
+        spell_stat = "WIS" if (pc and pc.archetype == "healer") else "INT"
+        spell_mod = p.get_stat_mod(spell_stat)
+        self._stat_pair("AC", str(ac), col1, y)
+        y += 22
+        atk_str = f"+{atk_mod}" if atk_mod >= 0 else str(atk_mod)
+        self._stat_pair("Attack Mod", atk_str, col1, y)
+        y += 22
+        spell_str = f"+{spell_mod}" if spell_mod >= 0 else str(spell_mod)
+        self._stat_pair(f"Spell Mod ({spell_stat})", spell_str, col1, y)
+        y += 30
+
+        # Right column: Survival and Records
+        y2 = 50
+        self._stat_line("-- Survival --", HEADER_COLOR, col2, y2)
+        y2 += 24
+        self._stat_pair("HP", f"{p.health}/{p.max_health}", col2, y2)
+        y2 += 22
+        self._stat_pair("Hunger", f"{p.hunger}/{p.max_hunger}", col2, y2)
+        y2 += 22
+        self._stat_pair("Thirst", f"{p.thirst}/{p.max_thirst}", col2, y2)
+        y2 += 36
+
+        self._stat_line("-- Quest Record --", HEADER_COLOR, col2, y2)
+        y2 += 24
+        self._stat_pair("Active", str(len(p.active_quests)), col2, y2)
+        y2 += 22
+        self._stat_pair("Completed", str(len(p.completed_quests)), col2, y2)
+        y2 += 22
+        self._stat_pair("Failed", str(len(p.failed_quests)), col2, y2)
+        y2 += 36
+
+        self._stat_line("-- Equipment --", HEADER_COLOR, col2, y2)
+        y2 += 24
+        weapon_name = p.equipped_weapon or "(none)"
+        self._stat_pair("Weapon", weapon_name, col2, y2)
+        y2 += 22
+        self._stat_pair("Gold", str(p.money), col2, y2)
+
+    def _stat_line(self, text: str, color, x: int, y: int):
+        surf = self.small_font.render(text, True, color)
+        self.screen.blit(surf, (x, y))
+
+    def _stat_pair(self, label: str, value: str, x: int, y: int):
+        label_surf = self.small_font.render(f"{label}:", True, STAT_LABEL_COLOR)
+        value_surf = self.small_font.render(value, True, STAT_VALUE_COLOR)
+        self.screen.blit(label_surf, (x, y))
+        self.screen.blit(value_surf, (x + 160, y))
+
+    # --- Spells/Abilities Tab ---
+
+    def _draw_spells(self):
+        y = 50
+
+        # Spells section
+        self._stat_line("-- Spells --", HEADER_COLOR, 40, y)
+        y += 28
+
+        if not self.player.spells:
+            self._stat_line("No spells known.", TEXT_COLOR, 60, y)
+            y += 24
+        else:
+            for spell in self.player.spells:
+                is_learned = spell.name in self.player.learned_spells
+                learned_tag = " (Learned)" if is_learned else ""
+                name_color = EQUIPPED_COLOR if is_learned else TEXT_COLOR
+
+                # Spell name and type
+                spell_type = getattr(spell, 'spell_type', 'unknown')
+                element = getattr(spell, 'element', '')
+                element_tag = f" [{element}]" if element else ""
+                line = f"{spell.name}{learned_tag} - {spell_type}{element_tag}"
+                self._stat_line(line, name_color, 60, y)
+                y += 20
+
+                # Cost and effect
+                h_cost = getattr(spell, 'cost_hunger', getattr(spell, 'hunger_cost', 0))
+                t_cost = getattr(spell, 'cost_thirst', getattr(spell, 'thirst_cost', 0))
+                cost_parts = []
+                if h_cost:
+                    cost_parts.append(f"Hunger: {h_cost}")
+                if t_cost:
+                    cost_parts.append(f"Thirst: {t_cost}")
+                cost_str = "  |  ".join(cost_parts) if cost_parts else "Free"
+
+                desc = getattr(spell, 'description', '')
+                detail = f"Cost: {cost_str}"
+                if desc:
+                    detail += f"  |  {desc[:50]}"
+                detail_surf = self.small_font.render(detail, True, (120, 120, 140))
+                self.screen.blit(detail_surf, (80, y))
+                y += 24
+
+                if y > SCREEN_HEIGHT - 120:
+                    self._stat_line("... (more)", (120, 120, 120), 60, y)
+                    break
+
+        y += 12
+
+        # Abilities section
+        self._stat_line("-- Abilities --", HEADER_COLOR, 40, y)
+        y += 28
+
+        if not self.player.abilities:
+            self._stat_line("No abilities known.", TEXT_COLOR, 60, y)
+            y += 24
+        else:
+            for ability in self.player.abilities:
+                line = f"{ability.name} ({ability.stat})"
+                self._stat_line(line, TEXT_COLOR, 60, y)
+                y += 20
+
+                h_cost = getattr(ability, 'cost_hunger', 0)
+                t_cost = getattr(ability, 'cost_thirst', 0)
+                cost_parts = []
+                if h_cost:
+                    cost_parts.append(f"Hunger: {h_cost}")
+                if t_cost:
+                    cost_parts.append(f"Thirst: {t_cost}")
+                cost_str = "  |  ".join(cost_parts) if cost_parts else "Free"
+
+                desc = getattr(ability, 'description', '')
+                detail = f"Cost: {cost_str}"
+                if desc:
+                    detail += f"  |  {desc[:50]}"
+                detail_surf = self.small_font.render(detail, True, (120, 120, 140))
+                self.screen.blit(detail_surf, (80, y))
+                y += 24
+
+                if y > SCREEN_HEIGHT - 60:
+                    self._stat_line("... (more)", (120, 120, 120), 60, y)
+                    break
+
+    def handle_input(self, event) -> str | None:
+        """Returns 'close' on Esc, or None. Handles tab switching and item actions."""
+        if event.key == pygame.K_ESCAPE:
+            return "close"
+
+        if event.key == pygame.K_TAB:
+            self.active_tab = (self.active_tab + 1) % len(TABS)
+            self.selected_index = 0
+            self.scroll_offset = 0
+            return None
+
+        # Inventory-specific controls
+        if self.active_tab == 0:
+            return self._handle_inventory_input(event)
+
+        return None
+
+    def _handle_inventory_input(self, event) -> str | None:
+        items = list(self.player.inventory.values())
+        if not items:
+            return None
+
+        if event.key == pygame.K_UP:
+            self.selected_index = max(0, self.selected_index - 1)
+        elif event.key == pygame.K_DOWN:
+            self.selected_index = min(len(items) - 1, self.selected_index + 1)
+        elif event.key in (pygame.K_RETURN, pygame.K_u):
+            message = self.player.use_item()
+            self.action_message = message
+            self.action_message_timer = 60
+        elif event.key == pygame.K_e:
+            inv_list = self.player.get_inventory()
+            if self.selected_index < len(inv_list):
+                item_name = inv_list[self.selected_index][0]
+                message = self.player.equip_weapon(item_name)
+                self.action_message = message
+                self.action_message_timer = 60
+        elif event.key == pygame.K_d:
+            inv_list = self.player.get_inventory()
+            if self.selected_index < len(inv_list):
+                item_name = inv_list[self.selected_index][0]
+                self.player.remove_from_inventory(item_name)
+                self.action_message = f"Dropped {item_name}."
+                self.action_message_timer = 60
+                if self.selected_index >= len(self.player.inventory):
+                    self.selected_index = max(0, len(self.player.inventory) - 1)
+        return None

--- a/src/views/menu_view.py
+++ b/src/views/menu_view.py
@@ -1,7 +1,7 @@
 """Tabbed player menu view — Inventory, Stats, Spells/Abilities tabs."""
 
 import pygame
-from config import SCREEN_WIDTH, SCREEN_HEIGHT, BLACK
+from config import SCREEN_WIDTH, SCREEN_HEIGHT
 
 TITLE_COLOR = (220, 180, 60)
 TAB_ACTIVE_COLOR = (255, 255, 100)
@@ -365,6 +365,7 @@ class MenuView:
         elif event.key == pygame.K_DOWN:
             self.selected_index = min(len(items) - 1, self.selected_index + 1)
         elif event.key in (pygame.K_RETURN, pygame.K_u):
+            self.player.selected_item_index = self.selected_index
             message = self.player.use_item()
             self.action_message = message
             self.action_message_timer = 60

--- a/src/views/pause_view.py
+++ b/src/views/pause_view.py
@@ -1,1 +1,137 @@
-"""Pause screen view — stub for later phases."""
+"""Pause screen — overlay on gameplay with Resume, Save, Controls, Quit."""
+
+import pygame
+from config import SCREEN_WIDTH, SCREEN_HEIGHT, BLACK
+
+TITLE_COLOR = (220, 180, 60)
+SELECTED_COLOR = (255, 255, 100)
+UNSELECTED_COLOR = (180, 180, 180)
+DISABLED_COLOR = (80, 80, 80)
+TEXT_COLOR = (200, 200, 200)
+
+MENU_ITEMS = ["Resume", "Save Game", "Controls", "Quit to Start"]
+
+CONTROLS_TEXT = [
+    "Arrow Keys  -  Move",
+    "Enter       -  Interact / Pick up",
+    "Esc         -  Pause / Back",
+    "Tab         -  Player Menu",
+    "I           -  Inventory",
+    "Q           -  Quest Log",
+    "S           -  Shop (near merchant)",
+    "T           -  Talk to follower",
+    "F1          -  Toggle debug view",
+    "",
+    "Combat:",
+    "A           -  Attack",
+    "F           -  Flee",
+    "I           -  Use item",
+    "Up/Down     -  Select target",
+]
+
+
+class PauseView:
+    """Pause overlay with Resume, Save, Controls, and Quit options."""
+
+    def __init__(self, screen, font, can_save=True):
+        self.screen = screen
+        self.font = font
+        self.title_font = pygame.font.Font(None, 48)
+        self.small_font = pygame.font.Font(None, 22)
+        self.selected_index = 0
+        self.can_save = can_save
+        self.showing_controls = False
+        self.status_message = ""
+        self.status_is_error = False
+
+    def set_status(self, message: str, is_error: bool = False):
+        self.status_message = message
+        self.status_is_error = is_error
+
+    def draw(self):
+        # Semi-transparent overlay
+        overlay = pygame.Surface((SCREEN_WIDTH, SCREEN_HEIGHT))
+        overlay.fill(BLACK)
+        overlay.set_alpha(200)
+        self.screen.blit(overlay, (0, 0))
+
+        if self.showing_controls:
+            self._draw_controls()
+            return
+
+        # Title
+        title = self.title_font.render("PAUSED", True, TITLE_COLOR)
+        self.screen.blit(title, ((SCREEN_WIDTH - title.get_width()) // 2, SCREEN_HEIGHT // 4))
+
+        # Menu items
+        line_height = self.font.get_linesize()
+        start_y = SCREEN_HEIGHT // 2 - 40
+
+        for i, item in enumerate(MENU_ITEMS):
+            disabled = (item == "Save Game" and not self.can_save)
+            if disabled:
+                color = DISABLED_COLOR
+            elif i == self.selected_index:
+                color = SELECTED_COLOR
+            else:
+                color = UNSELECTED_COLOR
+
+            prefix = "> " if i == self.selected_index else "  "
+            label = item
+            if disabled:
+                label += " (unavailable)"
+            surf = self.font.render(f"{prefix}{label}", True, color)
+            self.screen.blit(surf, ((SCREEN_WIDTH - surf.get_width()) // 2,
+                                    start_y + i * (line_height + 10)))
+
+        # Status message
+        if self.status_message:
+            color = (200, 100, 100) if self.status_is_error else (100, 200, 100)
+            msg = self.font.render(self.status_message, True, color)
+            self.screen.blit(msg, ((SCREEN_WIDTH - msg.get_width()) // 2,
+                                   start_y + len(MENU_ITEMS) * (line_height + 10) + 20))
+
+    def _draw_controls(self):
+        title = self.title_font.render("CONTROLS", True, TITLE_COLOR)
+        self.screen.blit(title, ((SCREEN_WIDTH - title.get_width()) // 2, 60))
+
+        y = 120
+        for line in CONTROLS_TEXT:
+            if not line:
+                y += 10
+                continue
+            surf = self.small_font.render(line, True, TEXT_COLOR)
+            self.screen.blit(surf, (SCREEN_WIDTH // 2 - 150, y))
+            y += 24
+
+        hint = self.small_font.render("Press Esc to go back", True, (120, 120, 120))
+        self.screen.blit(hint, ((SCREEN_WIDTH - hint.get_width()) // 2, SCREEN_HEIGHT - 40))
+
+    def handle_input(self, event) -> str | None:
+        """Returns 'resume', 'save', 'controls', 'quit_to_start', or None."""
+        if self.showing_controls:
+            if event.key == pygame.K_ESCAPE:
+                self.showing_controls = False
+            return None
+
+        if event.key == pygame.K_ESCAPE:
+            return "resume"
+
+        if event.key == pygame.K_UP:
+            self.selected_index = (self.selected_index - 1) % len(MENU_ITEMS)
+        elif event.key == pygame.K_DOWN:
+            self.selected_index = (self.selected_index + 1) % len(MENU_ITEMS)
+        elif event.key == pygame.K_RETURN:
+            selected = MENU_ITEMS[self.selected_index]
+            if selected == "Resume":
+                return "resume"
+            if selected == "Save Game":
+                if not self.can_save:
+                    return None
+                return "save"
+            if selected == "Controls":
+                self.showing_controls = True
+                return None
+            if selected == "Quit to Start":
+                return "quit_to_start"
+        return None

--- a/src/views/victory_view.py
+++ b/src/views/victory_view.py
@@ -1,1 +1,118 @@
-"""Victory screen view — stub for later phases."""
+"""Victory screen — story conclusion, full stats summary, and replay options."""
+
+import pygame
+from config import SCREEN_WIDTH, SCREEN_HEIGHT, BLACK
+
+TITLE_COLOR = (220, 200, 60)
+TEXT_COLOR = (200, 200, 200)
+HIGHLIGHT_COLOR = (255, 255, 150)
+SELECTED_COLOR = (255, 255, 100)
+UNSELECTED_COLOR = (180, 180, 180)
+
+MENU_ITEMS = ["Start New Game", "Quit"]
+
+
+class VictoryView:
+    """Victory screen with full stats summary and replay options."""
+
+    def __init__(self, screen, font, player, time_played: float = 0.0,
+                 monsters_killed: int = 0, damage_dealt: int = 0,
+                 damage_taken: int = 0, items_used: int = 0,
+                 money_earned: int = 0, rooms_cleared: int = 1):
+        self.screen = screen
+        self.font = font
+        self.title_font = pygame.font.Font(None, 56)
+        self.small_font = pygame.font.Font(None, 22)
+        self.player = player
+        self.time_played = time_played
+        self.monsters_killed = monsters_killed
+        self.damage_dealt = damage_dealt
+        self.damage_taken = damage_taken
+        self.items_used = items_used
+        self.money_earned = money_earned
+        self.rooms_cleared = rooms_cleared
+        self.selected_index = 0
+        self.scroll_offset = 0
+
+    def _format_time(self, seconds: float) -> str:
+        m, s = divmod(int(seconds), 60)
+        h, m = divmod(m, 60)
+        if h > 0:
+            return f"{h}h {m}m {s}s"
+        return f"{m}m {s}s"
+
+    def draw(self):
+        self.screen.fill(BLACK)
+
+        # Title
+        title = self.title_font.render("VICTORY", True, TITLE_COLOR)
+        self.screen.blit(title, ((SCREEN_WIDTH - title.get_width()) // 2, 30))
+
+        # Story conclusion
+        name = self.player.name
+        cls_name = self.player.player_class.name if self.player.player_class else "Adventurer"
+        env = self.player.player_class.environment if self.player.player_class else "the unknown"
+        conclusion = f"{name} the {cls_name} has conquered {env}!"
+        conc_surf = self.font.render(conclusion, True, HIGHLIGHT_COLOR)
+        self.screen.blit(conc_surf, ((SCREEN_WIDTH - conc_surf.get_width()) // 2, 80))
+
+        # Stats summary
+        stats_lines = [
+            ("Class", cls_name),
+            ("Level", str(self.player.level)),
+            ("Environment", env),
+            ("Rooms Cleared", str(self.rooms_cleared)),
+            ("", ""),
+            ("Quests Completed", str(len(self.player.completed_quests))),
+            ("Quests Failed", str(len(self.player.failed_quests))),
+            ("Active Quests", str(len(self.player.active_quests))),
+            ("", ""),
+            ("Monsters Killed", str(self.monsters_killed)),
+            ("Damage Dealt", str(self.damage_dealt)),
+            ("Damage Taken", str(self.damage_taken)),
+            ("", ""),
+            ("Items Used", str(self.items_used)),
+            ("Gold Earned", str(self.money_earned)),
+            ("Followers Escorted", str(len(self.player.followers))),
+            ("", ""),
+            ("Time Played", self._format_time(self.time_played)),
+        ]
+
+        y = 120 - self.scroll_offset
+        col_label_x = SCREEN_WIDTH // 2 - 160
+        col_value_x = SCREEN_WIDTH // 2 + 80
+        for label, value in stats_lines:
+            if y < 110 or y > SCREEN_HEIGHT - 130:
+                y += 24
+                continue
+            if not label:
+                y += 12
+                continue
+            label_surf = self.small_font.render(label, True, TEXT_COLOR)
+            value_surf = self.small_font.render(value, True, HIGHLIGHT_COLOR)
+            self.screen.blit(label_surf, (col_label_x, y))
+            self.screen.blit(value_surf, (col_value_x, y))
+            y += 24
+
+        # Menu options
+        y = SCREEN_HEIGHT - 100
+        for i, item in enumerate(MENU_ITEMS):
+            color = SELECTED_COLOR if i == self.selected_index else UNSELECTED_COLOR
+            prefix = "> " if i == self.selected_index else "  "
+            surf = self.font.render(f"{prefix}{item}", True, color)
+            self.screen.blit(surf, ((SCREEN_WIDTH - surf.get_width()) // 2, y))
+            y += 36
+
+    def handle_input(self, event) -> str | None:
+        """Returns 'new_game' or 'quit', or None."""
+        if event.key == pygame.K_UP:
+            self.selected_index = (self.selected_index - 1) % len(MENU_ITEMS)
+        elif event.key == pygame.K_DOWN:
+            self.selected_index = (self.selected_index + 1) % len(MENU_ITEMS)
+        elif event.key == pygame.K_RETURN:
+            selected = MENU_ITEMS[self.selected_index]
+            if selected == "Start New Game":
+                return "new_game"
+            if selected == "Quit":
+                return "quit"
+        return None

--- a/tests/test_survival.py
+++ b/tests/test_survival.py
@@ -9,9 +9,6 @@ from src.systems.survival import (
     SurvivalSystem,
     DRAIN_INTERVAL,
     STARVATION_INTERVAL,
-    THRESHOLD_WARNING,
-    THRESHOLD_PENALTY,
-    THRESHOLD_CRITICAL,
     BASE_HUNGER_DRAIN,
     BASE_THIRST_DRAIN,
     STARVATION_HP_DRAIN,
@@ -343,7 +340,7 @@ class TestNoDrainWhileStationary:
 
     def test_no_drain_without_move(self):
         """Survival system only drains on on_move(), not passively."""
-        survival = SurvivalSystem()
+        SurvivalSystem()
         player = _make_player(hunger=100, thirst=100)
         # Simply not calling on_move means no drain
         assert player.hunger == 100

--- a/tests/test_survival.py
+++ b/tests/test_survival.py
@@ -1,0 +1,391 @@
+"""Tests for Phase 9: Survival system, screen transitions, and menu views."""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.systems.survival import (
+    SurvivalSystem,
+    DRAIN_INTERVAL,
+    STARVATION_INTERVAL,
+    THRESHOLD_WARNING,
+    THRESHOLD_PENALTY,
+    THRESHOLD_CRITICAL,
+    BASE_HUNGER_DRAIN,
+    BASE_THIRST_DRAIN,
+    STARVATION_HP_DRAIN,
+)
+from src.models.player import PlayerCharacter, PlayerClass, Stats
+from src.controllers.screen_controller import ScreenController, ScreenState
+
+
+# --- Helpers ---
+
+def _make_player(con: int = 10, hunger: int = 100, thirst: int = 100, health: int = 100) -> PlayerCharacter:
+    """Create a player with a class that has a specific CON stat."""
+    stats = Stats(STR=10, DEX=10, CON=con, INT=10, WIS=10, CHA=10, LUCK=10)
+    pc = PlayerClass(name="TestClass", archetype="warrior", stats=stats)
+    player = PlayerCharacter(x=0, y=0)
+    player.apply_class(pc)
+    player.hunger = hunger
+    player.thirst = thirst
+    player.health = health
+    return player
+
+
+# --- Drain rate tests ---
+
+class TestDrainRates:
+
+    def test_no_drain_before_interval(self):
+        """No drain occurs until DRAIN_INTERVAL steps have passed."""
+        survival = SurvivalSystem()
+        player = _make_player(con=10)
+        initial_hunger = player.hunger
+        initial_thirst = player.thirst
+
+        # Move DRAIN_INTERVAL - 1 times: no drain yet
+        for _ in range(DRAIN_INTERVAL - 1):
+            survival.on_move(player)
+
+        assert player.hunger == initial_hunger
+        assert player.thirst == initial_thirst
+
+    def test_drain_at_interval(self):
+        """Drain occurs on the DRAIN_INTERVAL-th step."""
+        survival = SurvivalSystem()
+        player = _make_player(con=10)
+        initial_hunger = player.hunger
+
+        for _ in range(DRAIN_INTERVAL):
+            survival.on_move(player)
+
+        # CON 10 -> modifier 0, so drain is BASE_HUNGER_DRAIN (1)
+        assert player.hunger == initial_hunger - BASE_HUNGER_DRAIN
+        assert player.thirst == initial_hunger - BASE_THIRST_DRAIN
+
+    def test_drain_rate_one_third(self):
+        """Over 9 steps, drain should happen 3 times (interval=3), totaling 3 drain."""
+        survival = SurvivalSystem()
+        player = _make_player(con=10)
+        initial_hunger = player.hunger
+
+        for _ in range(9):
+            survival.on_move(player)
+
+        expected_drains = 9 // DRAIN_INTERVAL
+        assert player.hunger == initial_hunger - (expected_drains * BASE_HUNGER_DRAIN)
+
+    def test_con_modifier_reduces_drain(self):
+        """Higher CON reduces drain per tick (minimum 1)."""
+        survival = SurvivalSystem()
+        # CON 14 -> modifier +2 -> drain = max(1, 1-2) = 1 (minimum)
+        player_high_con = _make_player(con=14)
+        initial = player_high_con.hunger
+
+        for _ in range(DRAIN_INTERVAL):
+            survival.on_move(player_high_con)
+
+        # Even with high CON, minimum drain is 1
+        assert player_high_con.hunger == initial - 1
+
+    def test_con_modifier_minimum_drain(self):
+        """CON modifier can't reduce drain below 1."""
+        survival = SurvivalSystem()
+        # CON 18 -> modifier +4 -> max(1, 1-4) = 1
+        player = _make_player(con=18)
+        initial = player.hunger
+
+        for _ in range(DRAIN_INTERVAL):
+            survival.on_move(player)
+
+        assert player.hunger == initial - 1
+
+    def test_low_con_increases_drain(self):
+        """Low CON (negative modifier) increases drain."""
+        survival = SurvivalSystem()
+        # CON 6 -> modifier -2 -> drain = max(1, 1-(-2)) = 3
+        player = _make_player(con=6)
+        initial = player.hunger
+
+        for _ in range(DRAIN_INTERVAL):
+            survival.on_move(player)
+
+        expected_drain = max(1, BASE_HUNGER_DRAIN - ((6 - 10) // 2))
+        assert player.hunger == initial - expected_drain
+
+
+# --- Starvation / dehydration HP drain ---
+
+class TestStarvation:
+
+    def test_no_hp_drain_when_fed(self):
+        """No HP drain when hunger and thirst are above 0."""
+        survival = SurvivalSystem()
+        player = _make_player(hunger=50, thirst=50)
+        initial_hp = player.health
+
+        for _ in range(STARVATION_INTERVAL * 2):
+            survival.on_move(player)
+
+        assert player.health == initial_hp
+
+    def test_hp_drain_when_starving(self):
+        """HP drains at rate of 1 per STARVATION_INTERVAL steps when hunger is 0."""
+        survival = SurvivalSystem()
+        player = _make_player(hunger=0, thirst=50, health=100)
+        initial_hp = player.health
+
+        for _ in range(STARVATION_INTERVAL):
+            survival.on_move(player)
+
+        assert player.health == initial_hp - STARVATION_HP_DRAIN
+
+    def test_hp_drain_when_dehydrated(self):
+        """HP drains when thirst is 0."""
+        survival = SurvivalSystem()
+        player = _make_player(hunger=50, thirst=0, health=100)
+        initial_hp = player.health
+
+        for _ in range(STARVATION_INTERVAL):
+            survival.on_move(player)
+
+        assert player.health == initial_hp - STARVATION_HP_DRAIN
+
+    def test_hp_drain_rate(self):
+        """HP drains at exactly 1 per 5 steps when starving."""
+        survival = SurvivalSystem()
+        player = _make_player(hunger=0, thirst=50, health=100)
+        initial_hp = player.health
+
+        for _ in range(STARVATION_INTERVAL * 3):
+            survival.on_move(player)
+
+        assert player.health == initial_hp - (3 * STARVATION_HP_DRAIN)
+
+    def test_health_cannot_go_below_zero(self):
+        """Health floors at 0."""
+        survival = SurvivalSystem()
+        player = _make_player(hunger=0, thirst=0, health=1)
+
+        for _ in range(STARVATION_INTERVAL * 5):
+            survival.on_move(player)
+
+        assert player.health == 0
+
+    def test_starvation_counter_resets_when_fed(self):
+        """Starvation counter resets when hunger goes back above 0."""
+        survival = SurvivalSystem()
+        player = _make_player(hunger=0, thirst=50, health=100)
+
+        # Partially count toward starvation
+        for _ in range(STARVATION_INTERVAL - 1):
+            survival.on_move(player)
+
+        # Feed the player
+        player.hunger = 50
+
+        # Move more — counter should have reset
+        for _ in range(STARVATION_INTERVAL - 1):
+            survival.on_move(player)
+
+        assert player.health == 100  # No HP lost
+
+
+# --- Spell effectiveness ---
+
+class TestSpellEffectiveness:
+
+    def test_full_effectiveness(self):
+        survival = SurvivalSystem()
+        player = _make_player(hunger=50, thirst=50)
+        assert survival.get_spell_effectiveness(player) == 1.0
+
+    def test_reduced_effectiveness_at_penalty(self):
+        survival = SurvivalSystem()
+        player = _make_player(hunger=10, thirst=50)
+        assert survival.get_spell_effectiveness(player) == 0.5
+
+    def test_zero_effectiveness_at_critical(self):
+        survival = SurvivalSystem()
+        player = _make_player(hunger=0, thirst=50)
+        assert survival.get_spell_effectiveness(player) == 0.0
+
+    def test_cant_cast_at_critical(self):
+        survival = SurvivalSystem()
+        player = _make_player(hunger=0, thirst=50)
+        assert survival.can_cast(player) is False
+
+    def test_can_cast_above_critical(self):
+        survival = SurvivalSystem()
+        player = _make_player(hunger=1, thirst=1)
+        assert survival.can_cast(player) is True
+
+
+# --- Spell cost + drain balance ---
+
+class TestSpellCostBalance:
+
+    def test_spell_cost_deducted(self):
+        """Spell costs are properly deducted from hunger/thirst."""
+        from src.models.player import Spell
+        player = _make_player(hunger=50, thirst=50)
+        spell = Spell(name="Fireball", description="Fire!", element="fire",
+                      cost_hunger=5, cost_thirst=0)
+        assert player.can_afford_spell(spell)
+        player.pay_spell_cost(spell)
+        assert player.hunger == 45
+        assert player.thirst == 50
+
+    def test_cannot_afford_spell(self):
+        """Can't cast when resources too low."""
+        from src.models.player import Spell
+        player = _make_player(hunger=3, thirst=50)
+        spell = Spell(name="Fireball", description="Fire!", element="fire",
+                      cost_hunger=5, cost_thirst=0)
+        assert not player.can_afford_spell(spell)
+
+    def test_spell_drain_interaction(self):
+        """After several moves with drain, verify spell costs still work."""
+        survival = SurvivalSystem()
+        from src.models.player import Spell
+        player = _make_player(con=10, hunger=100, thirst=100)
+        spell = Spell(name="Heal", description="Heal", element="light",
+                      cost_hunger=0, cost_thirst=8)
+
+        # Move enough to drain some thirst
+        for _ in range(DRAIN_INTERVAL * 5):
+            survival.on_move(player)
+
+        # Should still be able to afford
+        assert player.can_afford_spell(spell)
+        player.pay_spell_cost(spell)
+        expected_thirst = 100 - 5 - 8  # 5 drains of 1, then 8 spell cost
+        assert player.thirst == expected_thirst
+
+
+# --- Screen transition tests ---
+
+class TestScreenTransitions:
+
+    def test_esc_from_pause_returns_to_gameplay(self):
+        sc = ScreenController(ScreenState.GAMEPLAY)
+        sc.push(ScreenState.PAUSE)
+        assert sc.state == ScreenState.PAUSE
+        sc.pop()
+        assert sc.state == ScreenState.GAMEPLAY
+
+    def test_esc_from_menu_returns_to_gameplay(self):
+        sc = ScreenController(ScreenState.GAMEPLAY)
+        sc.push(ScreenState.PLAYER_MENU)
+        assert sc.state == ScreenState.PLAYER_MENU
+        sc.pop()
+        assert sc.state == ScreenState.GAMEPLAY
+
+    def test_esc_stacking_inventory_menu_gameplay(self):
+        """Esc from inventory tab -> player menu -> gameplay."""
+        sc = ScreenController(ScreenState.GAMEPLAY)
+        sc.push(ScreenState.PLAYER_MENU)
+        # Simulating: in player menu, user would navigate tabs
+        # Esc closes menu back to gameplay
+        sc.pop()
+        assert sc.state == ScreenState.GAMEPLAY
+
+    def test_game_over_to_start(self):
+        sc = ScreenController(ScreenState.GAMEPLAY)
+        sc.push(ScreenState.GAME_OVER)
+        assert sc.state == ScreenState.GAME_OVER
+        sc.reset_to(ScreenState.START)
+        assert sc.state == ScreenState.START
+        assert sc.depth == 1
+
+    def test_victory_to_start(self):
+        sc = ScreenController(ScreenState.GAMEPLAY)
+        sc.push(ScreenState.VICTORY)
+        assert sc.state == ScreenState.VICTORY
+        sc.reset_to(ScreenState.START)
+        assert sc.state == ScreenState.START
+
+    def test_pause_save_stays_on_pause(self):
+        """After saving from pause, screen stays on pause."""
+        sc = ScreenController(ScreenState.GAMEPLAY)
+        sc.push(ScreenState.PAUSE)
+        # Save action doesn't change screen state
+        assert sc.state == ScreenState.PAUSE
+
+    def test_pause_to_load(self):
+        sc = ScreenController(ScreenState.GAMEPLAY)
+        sc.push(ScreenState.PAUSE)
+        sc.push(ScreenState.LOAD_GAME)
+        assert sc.state == ScreenState.LOAD_GAME
+        sc.pop()
+        assert sc.state == ScreenState.PAUSE
+
+    def test_full_esc_chain(self):
+        """Esc from deep nesting: load -> pause -> gameplay."""
+        sc = ScreenController(ScreenState.GAMEPLAY)
+        sc.push(ScreenState.PAUSE)
+        sc.push(ScreenState.LOAD_GAME)
+        assert sc.depth == 3
+
+        sc.pop()  # LOAD_GAME -> PAUSE
+        assert sc.state == ScreenState.PAUSE
+        sc.pop()  # PAUSE -> GAMEPLAY
+        assert sc.state == ScreenState.GAMEPLAY
+        sc.pop()  # Base — stays
+        assert sc.state == ScreenState.GAMEPLAY
+
+
+# --- No drain while stationary ---
+
+class TestNoDrainWhileStationary:
+
+    def test_no_drain_without_move(self):
+        """Survival system only drains on on_move(), not passively."""
+        survival = SurvivalSystem()
+        player = _make_player(hunger=100, thirst=100)
+        # Simply not calling on_move means no drain
+        assert player.hunger == 100
+        assert player.thirst == 100
+
+    def test_drain_only_on_movement(self):
+        """Verify that survival tracking is movement-triggered."""
+        survival = SurvivalSystem()
+        player = _make_player(hunger=100, thirst=100)
+
+        # Move exactly DRAIN_INTERVAL times
+        for _ in range(DRAIN_INTERVAL):
+            survival.on_move(player)
+
+        hunger_after = player.hunger
+        thirst_after = player.thirst
+
+        # No more moves — values shouldn't change
+        assert player.hunger == hunger_after
+        assert player.thirst == thirst_after
+
+
+# --- Warning messages ---
+
+class TestWarnings:
+
+    def test_starvation_message(self):
+        survival = SurvivalSystem()
+        player = _make_player(hunger=0, thirst=50, health=100)
+
+        messages = []
+        for _ in range(STARVATION_INTERVAL):
+            messages.extend(survival.on_move(player))
+
+        assert any("starving" in m.lower() for m in messages)
+
+    def test_dehydration_message(self):
+        survival = SurvivalSystem()
+        player = _make_player(hunger=50, thirst=0, health=100)
+
+        messages = []
+        for _ in range(STARVATION_INTERVAL):
+            messages.extend(survival.on_move(player))
+
+        assert any("dehydrated" in m.lower() for m in messages)


### PR DESCRIPTION
## Summary
- Implement `SurvivalSystem` with reduced drain rates (~1/3 of original), CON modifier reducing drain, no drain while stationary, threshold-based penalties (warning <30, penalty <15, critical =0), and starvation/dehydration HP drain (1 HP per 5 steps at 0)
- Add game over, victory, pause, and tabbed player menu (Inventory/Stats/Spells) screens with full UI
- Wire up Esc-to-close stacking behavior throughout all screen layers (Esc from submenu -> menu -> gameplay)
- 32 new tests covering drain rates at various CON levels, starvation HP drain rate, spell cost + drain balance, and all screen transitions

## Test plan
- [x] All 550 tests pass (32 new + 518 existing)
- [ ] Manual playtest: verify drain rates feel fair over extended gameplay
- [ ] Manual playtest: verify Esc stacking works from all screens
- [ ] Manual playtest: verify game over triggers on starvation death