### PR TITLE
Add consumable price/stat scaling by room level

### DIFF
--- a/src/generate/pipeline.py
+++ b/src/generate/pipeline.py
@@ -449,6 +449,19 @@ WEAPON_PRICE_BY_DICE = {
     "1d10": (40, 55), "2d4": (25, 35), "1d12": (55, 70),
 }
 
+# Consumable stat & price multipliers by room level
+CONSUMABLE_SCALING = {
+    1: 1.0,
+    2: 1.3,
+    3: 1.6,
+    4: 2.0,
+}
+
+
+def _consumable_mult(room_level: int) -> float:
+    """Return the consumable scaling multiplier for a given room level."""
+    return CONSUMABLE_SCALING.get(room_level, CONSUMABLE_SCALING[4])
+
 
 def _llm_generate_items(env_type: str, env_name: str, room_level: int = 1) -> dict | None:
     """Call LLM to generate environment-themed items. Returns items dict keyed by ID, or None."""
@@ -471,6 +484,7 @@ def _build_items_json(llm_result: dict, room_level: int) -> dict:
     """Convert LLM-generated item pools into the items.json format keyed by ID."""
     items = {}
     item_id = 200
+    mult = _consumable_mult(room_level)
 
     for raw in llm_result.get("food", [])[:4]:
         items[str(item_id)] = {
@@ -479,11 +493,11 @@ def _build_items_json(llm_result: dict, room_level: int) -> dict:
             "desc": raw.get("desc", ""),
             "room_level": room_level,
             "item_stats": {
-                "nutrition_value": raw.get("nutrition_value", 15),
+                "nutrition_value": int(raw.get("nutrition_value", 15) * mult),
                 "hydration_value": 0,
-                "health_value": raw.get("health_value", 0),
+                "health_value": int(raw.get("health_value", 0) * mult),
                 "uses": 1,
-                "price": random.randint(5, 15),
+                "price": int(random.randint(5, 15) * mult),
             },
         }
         item_id += 1
@@ -497,10 +511,10 @@ def _build_items_json(llm_result: dict, room_level: int) -> dict:
             "room_level": room_level,
             "item_stats": {
                 "nutrition_value": 0,
-                "hydration_value": raw.get("hydration_value", 15),
-                "health_value": raw.get("health_value", 0),
+                "hydration_value": int(raw.get("hydration_value", 15) * mult),
+                "health_value": int(raw.get("health_value", 0) * mult),
                 "uses": 1,
-                "price": random.randint(5, 15),
+                "price": int(random.randint(5, 15) * mult),
             },
         }
         item_id += 1
@@ -518,7 +532,7 @@ def _build_items_json(llm_result: dict, room_level: int) -> dict:
                 "hydration_value": -5,
                 "health_value": 0,
                 "uses": 3,
-                "price": random.randint(10, 25),
+                "price": int(random.randint(10, 25) * mult),
             },
         }
         item_id += 1
@@ -542,6 +556,7 @@ def _build_items_json(llm_result: dict, room_level: int) -> dict:
         item_id += 1
 
     item_id = 600
+    scroll_mult = 1.0 + (mult - 1.0) * 0.5  # scrolls scale at half rate
     for raw in llm_result.get("spell_scrolls", [])[:2]:
         items[str(item_id)] = {
             "category": "spell_scroll",
@@ -550,10 +565,10 @@ def _build_items_json(llm_result: dict, room_level: int) -> dict:
             "spell_effect": raw.get("spell_effect", "generic"),
             "room_level": room_level,
             "item_stats": {
-                "health_value": 25 if raw.get("spell_effect") == "heal" else 0,
-                "nutrition_value": 30 if raw.get("spell_effect") == "sustain" else 0,
-                "hydration_value": 30 if raw.get("spell_effect") == "sustain" else 0,
-                "price": random.randint(20, 40),
+                "health_value": int((25 if raw.get("spell_effect") == "heal" else 0) * scroll_mult),
+                "nutrition_value": int((30 if raw.get("spell_effect") == "sustain" else 0) * scroll_mult),
+                "hydration_value": int((30 if raw.get("spell_effect") == "sustain" else 0) * scroll_mult),
+                "price": int(random.randint(20, 40) * mult),
             },
         }
         item_id += 1

--- a/tests/test_items_phase4.py
+++ b/tests/test_items_phase4.py
@@ -230,10 +230,8 @@ def test_use_spell_scroll_not_scroll():
 
 # --- Item generation helpers ---
 
-def test_build_items_json_structure():
-    """Test _build_items_json converts LLM output to proper items.json format."""
-    from src.generate.pipeline import _build_items_json
-    llm_result = {
+def _sample_llm_result():
+    return {
         "food": [
             {"name": "forest bread", "desc": "Hearty bread.", "nutrition_value": 20, "health_value": 0},
             {"name": "berries", "desc": "Wild berries.", "nutrition_value": 10, "health_value": 5},
@@ -252,7 +250,12 @@ def test_build_items_json_structure():
             {"name": "scroll of heal", "desc": "Heals wounds.", "spell_effect": "heal"},
         ],
     }
-    items = _build_items_json(llm_result, room_level=1)
+
+
+def test_build_items_json_structure():
+    """Test _build_items_json converts LLM output to proper items.json format."""
+    from src.generate.pipeline import _build_items_json
+    items = _build_items_json(_sample_llm_result(), room_level=1)
     # Check food IDs start at 200
     assert "200" in items
     assert items["200"]["category"] == "food"
@@ -304,3 +307,80 @@ def test_validate_puzzle_tools():
     assert events[0]["choices"][0]["tool_attribute"] == "cutting"
     # None stays None
     assert events[0]["choices"][1]["tool_attribute"] is None
+
+
+# --- Consumable scaling tests ---
+
+def test_consumable_scaling_level_1_no_change():
+    """At room_level 1 the multiplier is 1.0 so stats stay at base values."""
+    from src.generate.pipeline import _build_items_json
+    items = _build_items_json(_sample_llm_result(), room_level=1)
+    assert items["200"]["item_stats"]["nutrition_value"] == 20
+    assert items["300"]["item_stats"]["hydration_value"] == 15
+
+
+def test_consumable_scaling_level_3():
+    """At room_level 3 the multiplier is 1.6 — stats and prices should increase."""
+    from src.generate.pipeline import _build_items_json
+    import random
+    random.seed(42)
+    items = _build_items_json(_sample_llm_result(), room_level=3)
+    # nutrition_value 20 * 1.6 = 32
+    assert items["200"]["item_stats"]["nutrition_value"] == 32
+    # hydration_value 15 * 1.6 = 24
+    assert items["300"]["item_stats"]["hydration_value"] == 24
+    # prices should be > base (base range 5-15, scaled by 1.6)
+    assert items["200"]["item_stats"]["price"] >= 8
+
+
+def test_consumable_scaling_level_4():
+    """At room_level 4 the multiplier is 2.0 — stats double."""
+    from src.generate.pipeline import _build_items_json
+    items = _build_items_json(_sample_llm_result(), room_level=4)
+    assert items["200"]["item_stats"]["nutrition_value"] == 40  # 20 * 2.0
+    assert items["300"]["item_stats"]["hydration_value"] == 30  # 15 * 2.0
+
+
+def test_consumable_scaling_high_level_caps_at_4():
+    """Room levels above 4 use the level-4 multiplier (2.0)."""
+    from src.generate.pipeline import _build_items_json
+    items = _build_items_json(_sample_llm_result(), room_level=7)
+    assert items["200"]["item_stats"]["nutrition_value"] == 40  # same as level 4
+
+
+def test_tool_uses_not_scaled():
+    """Tool uses should remain constant regardless of room level."""
+    from src.generate.pipeline import _build_items_json
+    items_l1 = _build_items_json(_sample_llm_result(), room_level=1)
+    items_l4 = _build_items_json(_sample_llm_result(), room_level=4)
+    assert items_l1["400"]["item_stats"]["uses"] == 3
+    assert items_l4["400"]["item_stats"]["uses"] == 3
+
+
+def test_tool_price_scales():
+    """Tool prices should increase with room level."""
+    from src.generate.pipeline import _build_items_json
+    import random
+    random.seed(42)
+    items_l1 = _build_items_json(_sample_llm_result(), room_level=1)
+    random.seed(42)
+    items_l4 = _build_items_json(_sample_llm_result(), room_level=4)
+    assert items_l4["400"]["item_stats"]["price"] >= items_l1["400"]["item_stats"]["price"]
+
+
+def test_spell_scroll_scales_at_half_rate():
+    """Spell scroll effects scale at half the consumable rate."""
+    from src.generate.pipeline import _build_items_json
+    items = _build_items_json(_sample_llm_result(), room_level=4)
+    # mult=2.0, scroll_mult = 1.0 + (2.0-1.0)*0.5 = 1.5
+    # heal scroll: 25 * 1.5 = 37
+    assert items["600"]["item_stats"]["health_value"] == 37
+
+
+def test_consumable_scaling_dict_values():
+    """Verify the CONSUMABLE_SCALING dict has expected values."""
+    from src.generate.pipeline import CONSUMABLE_SCALING
+    assert CONSUMABLE_SCALING[1] == 1.0
+    assert CONSUMABLE_SCALING[2] == 1.3
+    assert CONSUMABLE_SCALING[3] == 1.6
+    assert CONSUMABLE_SCALING[4] == 2.0


### PR DESCRIPTION
## Summary
- Add `CONSUMABLE_SCALING` dict mapping room levels 1-4 to stat/price multipliers (1.0x, 1.3x, 1.6x, 2.0x)
- Scale food/drink nutrition, hydration, and health values by room level in `_build_items_json()`
- Scale consumable and tool prices; tool uses remain constant
- Spell scroll effects scale at half the consumable rate for balance
- Add 8 new tests covering all scaling scenarios

## Test plan
- [x] All 35 tests in `test_items_phase4.py` pass
- [x] `ruff check` passes clean