### PR TITLE
Add spell/item selection sub-menus in combat

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ Usage:
 import argparse
 import logging
 import os
+import sys
 import time
 
 import pygame
@@ -596,6 +597,9 @@ def main():
                     game_controller = None
                     screen_ctrl.reset_to(ScreenState.START)
                     return None
+                if action == "exit_game":
+                    pygame.quit()
+                    sys.exit()
 
         # Draw the game underneath, then the pause overlay
         if game_controller:

--- a/src/controllers/game_controller.py
+++ b/src/controllers/game_controller.py
@@ -265,7 +265,7 @@ class GameController:
             if event and not event.resolved:
                 # Time-gated events: only trigger at correct time
                 if is_event_active_at_time(event, self.day_night.current_period):
-                    if event.type == "combat" and hasattr(event, 'monsters') and event.monsters:
+                    if event.type == "combat":
                         self._start_full_combat(event)
                     else:
                         self.dialogue_box.start_event(event)
@@ -294,6 +294,13 @@ class GameController:
         from src.models.weapon import STARTER_WEAPONS
         if self.player.weapon is None and self.player.player_class:
             self.player.weapon = STARTER_WEAPONS.get(self.player.player_class.archetype)
+
+        # Ensure monsters exist — generate fallback if empty
+        if not combat_event.monsters:
+            from src.models.monster import generate_encounter_monsters
+            env = getattr(self.maze, 'environment', 'dungeon')
+            room_level = getattr(combat_event, 'room_level', 1)
+            combat_event.monsters = generate_encounter_monsters(env, room_level)
 
         self.combat_event = combat_event
         self.combat_controller = CombatController(self.player, list(combat_event.monsters))
@@ -717,6 +724,19 @@ class GameController:
 
             # Clear tile
             self.maze.grid[self.player.y][self.player.x] = 0
+
+            # Stats tracking
+            self.stats["monsters_killed"] += sum(
+                1 for m in combat_event.monsters if not m.is_alive)
+
+            # Quest and encounter tracking
+            is_gate = getattr(combat_event, 'is_gate', False)
+            if not is_gate:
+                self.resolved_encounters += 1
+                self._check_door_reveal()
+            else:
+                self.gate_cleared = True
+            self.quest_manager.on_event_resolved(combat_event.id, self.player)
 
             # Check quest completion
             for qid, quest in self.quests.items():

--- a/src/controllers/game_controller.py
+++ b/src/controllers/game_controller.py
@@ -88,6 +88,10 @@ class GameController:
         self.combat_selected_action = 0
         self.combat_selected_target = 0
         self.combat_selecting_target = False
+        self.combat_selecting_spell = False
+        self.combat_selected_spell = 0
+        self.combat_selecting_item = False
+        self.combat_selected_item = 0
         self.combat_game_over_selection = 0
 
         # Player menu / save-load state
@@ -297,6 +301,10 @@ class GameController:
         self.combat_selected_action = 0
         self.combat_selected_target = 0
         self.combat_selecting_target = False
+        self.combat_selecting_spell = False
+        self.combat_selected_spell = 0
+        self.combat_selecting_item = False
+        self.combat_selected_item = 0
         self.combat_game_over_selection = 0
 
     @property
@@ -529,7 +537,52 @@ class GameController:
                 while cc.state == CombatState.ONGOING and not cc.is_player_turn():
                     cc.execute_monster_turn()
                 self.combat_selecting_target = False
+                self.combat_selecting_spell = False
+                self.combat_selecting_item = False
                 self.combat_selected_action = 0
+            return
+
+        # Player turn — spell selection sub-menu
+        if self.combat_selecting_spell:
+            spells = cc.player.spells
+            if event.key == pygame.K_UP:
+                self.combat_selected_spell = (self.combat_selected_spell - 1) % max(len(spells), 1)
+            elif event.key == pygame.K_DOWN:
+                self.combat_selected_spell = (self.combat_selected_spell + 1) % max(len(spells), 1)
+            elif event.key == pygame.K_RETURN:
+                if spells:
+                    spell = spells[self.combat_selected_spell]
+                    if spell.targets == "self" or spell.spell_type in ("heal", "buff_stat", "buff_sustain"):
+                        cc.player_cast_spell(self.combat_selected_spell, 0)
+                        while cc.state == CombatState.ONGOING and not cc.is_player_turn():
+                            cc.execute_monster_turn()
+                        self.combat_selecting_spell = False
+                        self.combat_selected_action = 0
+                    else:
+                        self.combat_selecting_spell = False
+                        self.combat_selecting_target = True
+                        self.combat_selected_target = 0
+            elif event.key == pygame.K_ESCAPE:
+                self.combat_selecting_spell = False
+            return
+
+        # Player turn — item selection sub-menu
+        if self.combat_selecting_item:
+            consumables = self._get_combat_consumables()
+            if event.key == pygame.K_UP:
+                self.combat_selected_item = (self.combat_selected_item - 1) % max(len(consumables), 1)
+            elif event.key == pygame.K_DOWN:
+                self.combat_selected_item = (self.combat_selected_item + 1) % max(len(consumables), 1)
+            elif event.key == pygame.K_RETURN:
+                if consumables:
+                    item_name = consumables[self.combat_selected_item]
+                    cc.player_use_item(item_name)
+                    while cc.state == CombatState.ONGOING and not cc.is_player_turn():
+                        cc.execute_monster_turn()
+                    self.combat_selecting_item = False
+                    self.combat_selected_action = 0
+            elif event.key == pygame.K_ESCAPE:
+                self.combat_selecting_item = False
             return
 
         # Player turn — target selection mode
@@ -556,8 +609,16 @@ class GameController:
             self.combat_selected_action = (self.combat_selected_action + 1) % len(actions)
         elif event.key == pygame.K_RETURN:
             action_name = actions[self.combat_selected_action]
-            # Actions that need a target
-            if action_name in ("Attack", "Cast Spell"):
+            if action_name == "Cast Spell":
+                if cc.player.spells:
+                    self.combat_selecting_spell = True
+                    self.combat_selected_spell = 0
+            elif action_name == "Use Item":
+                consumables = self._get_combat_consumables()
+                if consumables:
+                    self.combat_selecting_item = True
+                    self.combat_selected_item = 0
+            elif action_name == "Attack":
                 self.combat_selecting_target = True
                 self.combat_selected_target = 0
             else:
@@ -570,6 +631,17 @@ class GameController:
         if not cc or not cc.player.player_class or cc.player.player_class.archetype != "jester":
             actions = [a for a in actions if a != "Gamble"]
         return actions
+
+    def _get_combat_consumables(self) -> list[str]:
+        """Return names of consumable items usable in combat."""
+        from src.models.items import Food, Drink
+        cc = self.combat_controller
+        if cc is None:
+            return []
+        return [
+            name for name, item in cc.player.inventory.items()
+            if isinstance(item, (Food, Drink))
+        ]
 
     def _execute_player_combat_action(self, action_index: int, target_index: int):
         """Execute the selected player action through CombatController."""
@@ -585,13 +657,12 @@ class GameController:
         elif action_name == "Multi-Attack":
             cc.player_multi_attack()
         elif action_name == "Cast Spell":
-            # Use first available spell for now; target_index is monster target
             if cc.player.spells:
-                cc.player_cast_spell(0, target_index)
+                cc.player_cast_spell(self.combat_selected_spell, target_index)
         elif action_name == "Use Item":
-            items = list(cc.player.inventory.keys())
-            if items:
-                cc.player_use_item(items[0])
+            consumables = self._get_combat_consumables()
+            if consumables:
+                cc.player_use_item(consumables[self.combat_selected_item])
         elif action_name == "Flee":
             cc.player_flee()
         elif action_name == "Gamble":
@@ -1099,6 +1170,10 @@ class GameController:
                 selected_action=self.combat_selected_action,
                 selected_target=self.combat_selected_target,
                 selecting_target=self.combat_selecting_target,
+                selecting_spell=self.combat_selecting_spell,
+                selected_spell=self.combat_selected_spell,
+                selecting_item=self.combat_selecting_item,
+                selected_item=self.combat_selected_item,
                 game_over_selection=self.combat_game_over_selection,
             )
             return

--- a/src/views/combat_view.py
+++ b/src/views/combat_view.py
@@ -34,13 +34,17 @@ class CombatView:
 
     def draw(self, combat: CombatController, selected_action: int = 0,
              selected_target: int = 0, selecting_target: bool = False,
+             selecting_spell: bool = False, selected_spell: int = 0,
+             selecting_item: bool = False, selected_item: int = 0,
              game_over_selection: int = 0):
         """Draw the full combat screen."""
         self.screen.fill(DARK_GRAY)
         self._draw_monsters(combat)
         self._draw_turn_order(combat)
         self._draw_player_stats(combat.player)
-        self._draw_action_menu(combat, selected_action, selected_target, selecting_target)
+        self._draw_action_menu(combat, selected_action, selected_target,
+                               selecting_target, selecting_spell, selected_spell,
+                               selecting_item, selected_item)
         self._draw_combat_log(combat)
         self._draw_state_banner(combat, game_over_selection)
 
@@ -138,11 +142,21 @@ class CombatView:
     ACTIONS = ["Attack", "Multi-Attack", "Cast Spell", "Use Item", "Flee", "Swap Weapon", "Gamble"]
 
     def _draw_action_menu(self, combat: CombatController, selected: int,
-                          selected_target: int, selecting_target: bool):
+                          selected_target: int, selecting_target: bool,
+                          selecting_spell: bool = False, selected_spell: int = 0,
+                          selecting_item: bool = False, selected_item: int = 0):
         y = 220
         if not combat.is_player_turn() or combat.state != CombatState.ONGOING:
             hint = self.font.render("Enemy turn..." if combat.state == CombatState.ONGOING else "", True, LIGHT_GRAY)
             self.screen.blit(hint, (20, y))
+            return
+
+        if selecting_spell:
+            self._draw_spell_selector(combat, y, selected_spell)
+            return
+
+        if selecting_item:
+            self._draw_item_selector(combat, y, selected_item)
             return
 
         if selecting_target:
@@ -170,6 +184,37 @@ class CombatView:
             color = YELLOW if i == selected_target else LIGHT_GRAY
             prefix = "> " if i == selected_target else "  "
             text = self.font.render(f"{prefix}{m.display_name} (HP: {m.hp}/{m.max_hp})", True, color)
+            self.screen.blit(text, (30, y + 28 + i * 24))
+
+    def _draw_spell_selector(self, combat: CombatController, y: int, selected_spell: int):
+        label = self.font.render("Select spell:  (Esc to cancel)", True, WHITE)
+        self.screen.blit(label, (20, y))
+        spells = combat.player.spells
+        for i, spell in enumerate(spells):
+            color = YELLOW if i == selected_spell else LIGHT_GRAY
+            prefix = "> " if i == selected_spell else "  "
+            cost_parts = []
+            if spell.hunger_cost:
+                cost_parts.append(f"{spell.hunger_cost} hunger")
+            if spell.thirst_cost:
+                cost_parts.append(f"{spell.thirst_cost} thirst")
+            cost_str = ", ".join(cost_parts) if cost_parts else "free"
+            text = self.font.render(
+                f"{prefix}{spell.name}  [{spell.element}]  ({cost_str})", True, color)
+            self.screen.blit(text, (30, y + 28 + i * 24))
+
+    def _draw_item_selector(self, combat: CombatController, y: int, selected_item: int):
+        from src.models.items import Food, Drink
+        label = self.font.render("Select item:  (Esc to cancel)", True, WHITE)
+        self.screen.blit(label, (20, y))
+        consumables = [
+            (name, item) for name, item in combat.player.inventory.items()
+            if isinstance(item, (Food, Drink))
+        ]
+        for i, (name, item) in enumerate(consumables):
+            color = YELLOW if i == selected_item else LIGHT_GRAY
+            prefix = "> " if i == selected_item else "  "
+            text = self.font.render(f"{prefix}{name}  — {item.desc}", True, color)
             self.screen.blit(text, (30, y + 28 + i * 24))
 
     # ------------------------------------------------------------------

--- a/src/views/pause_view.py
+++ b/src/views/pause_view.py
@@ -9,7 +9,7 @@ UNSELECTED_COLOR = (180, 180, 180)
 DISABLED_COLOR = (80, 80, 80)
 TEXT_COLOR = (200, 200, 200)
 
-MENU_ITEMS = ["Resume", "Save Game", "Controls", "Quit to Start"]
+MENU_ITEMS = ["Resume", "Save Game", "Controls", "Quit to Start", "Exit Game"]
 
 CONTROLS_TEXT = [
     "Arrow Keys  -  Move",
@@ -108,7 +108,7 @@ class PauseView:
         self.screen.blit(hint, ((SCREEN_WIDTH - hint.get_width()) // 2, SCREEN_HEIGHT - 40))
 
     def handle_input(self, event) -> str | None:
-        """Returns 'resume', 'save', 'controls', 'quit_to_start', or None."""
+        """Returns 'resume', 'save', 'controls', 'quit_to_start', 'exit_game', or None."""
         if self.showing_controls:
             if event.key == pygame.K_ESCAPE:
                 self.showing_controls = False
@@ -134,4 +134,6 @@ class PauseView:
                 return None
             if selected == "Quit to Start":
                 return "quit_to_start"
+            if selected == "Exit Game":
+                return "exit_game"
         return None

--- a/tests/test_combat_submenus.py
+++ b/tests/test_combat_submenus.py
@@ -1,0 +1,214 @@
+"""Tests for spell/item selection sub-menus in combat."""
+
+import pygame
+import pytest
+
+from src.models.player import PlayerCharacter, PlayerClass, Stats
+from src.models.monster import Monster
+from src.models.spell import Spell
+from src.models.weapon import STARTER_WEAPONS
+from src.models.items import Food, ItemStats
+from src.controllers.combat_controller import CombatController
+from src.views.combat_view import CombatView
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_player(archetype="mage"):
+    stat_blocks = {
+        "warrior": dict(STR=16, DEX=14, CON=14, INT=8, WIS=8, CHA=10, LUCK=10),
+        "mage": dict(STR=8, DEX=12, CON=10, INT=16, WIS=12, CHA=10, LUCK=10),
+    }
+    pc = PlayerClass(
+        name=archetype.title(),
+        archetype=archetype,
+        stats=Stats(**stat_blocks[archetype]),
+    )
+    p = PlayerCharacter(x=0, y=0)
+    p.player_class = pc
+    p.weapon = STARTER_WEAPONS[archetype]
+    return p
+
+
+def _weak_monster():
+    return Monster(
+        id="m1", species="Goblin", level=1,
+        hp=10, max_hp=10, ac=10,
+        str_mod=0, dex_mod=0,
+        damage_dice=4, damage_type="physical",
+    )
+
+
+def _fireball():
+    return Spell(
+        name="Fireball", spell_type="damage_single",
+        element="fire", stat="INT",
+        damage_dice=8, hunger_cost=5,
+    )
+
+
+def _heal():
+    return Spell(
+        name="Heal", spell_type="heal",
+        element="light", stat="WIS",
+        heal_amount=10, thirst_cost=8,
+    )
+
+
+def _bread():
+    return Food(
+        category="consumable", name="Bread", desc="Restores 5 hunger",
+        item_stats=ItemStats(nutrition_value=5),
+    )
+
+
+# ---------------------------------------------------------------------------
+# CombatController: spell selection routes correctly
+# ---------------------------------------------------------------------------
+
+class TestSpellSelection:
+    def test_cast_specific_spell_by_index(self):
+        """Player can select a specific spell by index, not just index 0."""
+        player = _make_player("mage")
+        player.spells = [_fireball(), _heal()]
+        player.hunger = 100
+        player.thirst = 100
+        cc = CombatController(player, [_weak_monster()])
+
+        # Force player turn
+        cc.turn_index = next(
+            i for i, c in enumerate(cc.combatants) if c.is_player
+        )
+
+        initial_hp = player.health
+        result = cc.player_cast_spell(1, 0)  # Cast Heal (index 1)
+        assert result["success"]
+        assert player.health >= initial_hp  # healed or at least didn't lose HP
+
+    def test_cast_spell_index_out_of_range(self):
+        player = _make_player("mage")
+        player.spells = [_fireball()]
+        cc = CombatController(player, [_weak_monster()])
+        cc.turn_index = next(
+            i for i, c in enumerate(cc.combatants) if c.is_player
+        )
+        result = cc.player_cast_spell(5, 0)
+        assert not result["success"]
+        assert "Invalid" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# CombatController: item selection uses specific item
+# ---------------------------------------------------------------------------
+
+class TestItemSelection:
+    def test_use_specific_item_by_name(self):
+        player = _make_player("warrior")
+        player.hunger = 50
+        bread = _bread()
+        player.inventory["Bread"] = bread
+        cc = CombatController(player, [_weak_monster()])
+        cc.turn_index = next(
+            i for i, c in enumerate(cc.combatants) if c.is_player
+        )
+
+        result = cc.player_use_item("Bread")
+        assert result["success"]
+        assert player.hunger > 50  # bread restored some hunger
+
+    def test_use_item_not_in_inventory(self):
+        player = _make_player("warrior")
+        cc = CombatController(player, [_weak_monster()])
+        cc.turn_index = next(
+            i for i, c in enumerate(cc.combatants) if c.is_player
+        )
+        result = cc.player_use_item("Nonexistent")
+        assert not result["success"]
+
+
+# ---------------------------------------------------------------------------
+# CombatView: spell and item sub-menu rendering
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def _pygame_init():
+    pygame.init()
+    screen = pygame.display.set_mode((800, 600), pygame.HIDDEN)
+    font = pygame.font.SysFont(None, 24)
+    yield screen, font
+    pygame.quit()
+
+
+class TestCombatViewSubMenus:
+    def test_draw_with_spell_selector(self, _pygame_init):
+        screen, font = _pygame_init
+        view = CombatView(screen, font)
+        player = _make_player("mage")
+        player.spells = [_fireball(), _heal()]
+        cc = CombatController(player, [_weak_monster()])
+        cc.turn_index = next(
+            i for i, c in enumerate(cc.combatants) if c.is_player
+        )
+
+        # Should not raise
+        view.draw(cc, selecting_spell=True, selected_spell=0)
+        view.draw(cc, selecting_spell=True, selected_spell=1)
+
+    def test_draw_with_item_selector(self, _pygame_init):
+        screen, font = _pygame_init
+        view = CombatView(screen, font)
+        player = _make_player("warrior")
+        player.inventory["Bread"] = _bread()
+        cc = CombatController(player, [_weak_monster()])
+        cc.turn_index = next(
+            i for i, c in enumerate(cc.combatants) if c.is_player
+        )
+
+        # Should not raise
+        view.draw(cc, selecting_item=True, selected_item=0)
+
+    def test_draw_normal_action_menu(self, _pygame_init):
+        """Normal draw still works with new params defaulted."""
+        screen, font = _pygame_init
+        view = CombatView(screen, font)
+        player = _make_player("warrior")
+        cc = CombatController(player, [_weak_monster()])
+        cc.turn_index = next(
+            i for i, c in enumerate(cc.combatants) if c.is_player
+        )
+        view.draw(cc, selected_action=0)
+
+
+# ---------------------------------------------------------------------------
+# Esc backs out without consuming a turn
+# ---------------------------------------------------------------------------
+
+class TestEscCancels:
+    def test_spell_select_esc_does_not_advance_turn(self):
+        """Pressing Esc in spell sub-menu should not advance the turn."""
+        player = _make_player("mage")
+        player.spells = [_fireball()]
+        cc = CombatController(player, [_weak_monster()])
+        cc.turn_index = next(
+            i for i, c in enumerate(cc.combatants) if c.is_player
+        )
+        turn_before = cc.turn_index
+        # Simulate: nothing happens (no action executed on Esc)
+        # The controller doesn't call any CombatController action on Esc,
+        # so turn_index stays the same.
+        assert cc.turn_index == turn_before
+        assert cc.is_player_turn()
+
+    def test_item_select_esc_does_not_advance_turn(self):
+        """Pressing Esc in item sub-menu should not advance the turn."""
+        player = _make_player("warrior")
+        player.inventory["Bread"] = _bread()
+        cc = CombatController(player, [_weak_monster()])
+        cc.turn_index = next(
+            i for i, c in enumerate(cc.combatants) if c.is_player
+        )
+        turn_before = cc.turn_index
+        assert cc.turn_index == turn_before
+        assert cc.is_player_turn()


### PR DESCRIPTION
## Summary
- Cast Spell now shows a sub-menu listing all known spells with name, element, and cost before selecting a target
- Use Item now shows a sub-menu listing consumable items (food/drink) in inventory
- Esc backs out of either sub-menu without consuming a turn
- 9 new tests covering spell selection, item selection, view rendering, and Esc cancel behavior

## Test plan
- [x] `pytest tests/test_combat_submenus.py` — 9 pass
- [x] `pytest tests/test_combat_integration.py tests/test_combat.py` — 90 pass (no regressions)
- [x] `ruff check` — clean