### PR TITLE
Phase 7: Final room climax boss, victory trigger, quest door reveal

### DIFF
--- a/src/controllers/game_controller.py
+++ b/src/controllers/game_controller.py
@@ -139,10 +139,13 @@ class GameController:
         self.total_encounters = sum(
             1 for e in self.events.values()
             if not getattr(e, 'is_gate', False)
+            and not getattr(e, 'is_climax_boss', False)
         )
         self.resolved_encounters = sum(
             1 for e in self.events.values()
-            if e.resolved and not getattr(e, 'is_gate', False)
+            if e.resolved
+            and not getattr(e, 'is_gate', False)
+            and not getattr(e, 'is_climax_boss', False)
         )
 
     @property
@@ -327,6 +330,9 @@ class GameController:
 
     def _signal_room_transition(self):
         """Signal the main loop to transition to the next room."""
+        if self.current_room >= self.total_rooms - 1:
+            self.pending_action = "victory"
+            return
         # Check for incomplete story quests
         undone = [q for q in self.quests.values()
                   if getattr(q, 'is_story_quest', False)
@@ -918,6 +924,8 @@ class GameController:
             self.stats["monsters_killed"] += sum(
                 1 for m in combat_event.monsters if not m.is_alive)
         if getattr(combat_event, 'is_climax_boss', False):
+            self.resolved_encounters += 1
+            self.gate_cleared = True
             self.pending_action = "victory"
         elif not getattr(combat_event, 'is_gate', False):
             self.resolved_encounters += 1

--- a/src/controllers/game_controller.py
+++ b/src/controllers/game_controller.py
@@ -39,6 +39,7 @@ class GameController:
 
         # Managers
         self.quest_manager = QuestManager(self.quests, self.events)
+        self.quest_manager.door_reveal_callback = self.reveal_door_from_quest
         self.follower_manager = FollowerManager(self.player, self.npcs, self.quests)
 
         # Build a lookup from grid position to event id
@@ -916,7 +917,9 @@ class GameController:
         if hasattr(combat_event, 'monsters'):
             self.stats["monsters_killed"] += sum(
                 1 for m in combat_event.monsters if not m.is_alive)
-        if not getattr(combat_event, 'is_gate', False):
+        if getattr(combat_event, 'is_climax_boss', False):
+            self.pending_action = "victory"
+        elif not getattr(combat_event, 'is_gate', False):
             self.resolved_encounters += 1
             self._check_door_reveal()
         else:

--- a/src/generate/pipeline.py
+++ b/src/generate/pipeline.py
@@ -864,6 +864,35 @@ def _generate_room(room_idx: int, num_rooms: int, story, room_dir: str,
         gate_encounter_id = gate_id
         maze.gate_encounter_id = gate_id
 
+    # --- Climax boss encounter (final room only) ---
+    if room_idx == num_rooms - 1 and num_rooms > 1:
+        boss_id = f"{event_id_prefix}climax_boss"
+        boss_level = room_level + 2
+        boss_name = story.final_boss_name or "The Dark Lord"
+        boss_monsters = generate_encounter_monsters(maze.environment, boss_level)
+        for m in boss_monsters:
+            m.hp = int(m.hp * 2.5)
+            m.max_hp = m.hp
+        climax_event = {
+            "id": boss_id,
+            "type": "combat",
+            "name": boss_name,
+            "description": f"{boss_name} stands before you — the final confrontation! {story.climax}",
+            "difficulty": 5,
+            "monsters": [m.to_dict() for m in boss_monsters],
+            "room_level": boss_level,
+            "is_climax_boss": True,
+            "portrait_prompt": _llm_generate_event_image({
+                "name": boss_name,
+                "description": f"The final boss: {boss_name}. {story.climax}",
+            }),
+            "profile_image": None,
+        }
+        if all_item_ids:
+            climax_event["loot_table"] = _generate_loot_table(all_item_ids, boss_level)
+            climax_event["money_drop"] = [boss_level * 10, boss_level * 30]
+        event_list.append(climax_event)
+
     # --- Door placement (for non-final rooms) ---
     if room_idx < num_rooms - 1:
         maze.place_door(player_start)
@@ -1035,6 +1064,34 @@ def _generate_room(room_idx: int, num_rooms: int, story, room_dir: str,
             "profile_image": None,
         }
         quest_list.append(multi_quest)
+        quest_id_counter += 1
+
+    # --- Door-reveal quest (one per non-final room) ---
+    if room_idx < num_rooms - 1 and npcs_for_quest and combat_events_for_quest:
+        dr_target = random.choice(combat_events_for_quest)
+        dr_giver_id = random.choice(npcs_for_quest)["id"]
+        door_reveal_quest = {
+            "id": f"{event_id_prefix}q_{quest_id_counter:03d}",
+            "type": "combat",
+            "title": f"Clear the Path: {dr_target['name']}",
+            "description": f"Defeat {dr_target['name']} and the exit will reveal itself.",
+            "giver_npc_id": dr_giver_id,
+            "target_event_id": dr_target["id"],
+            "room_id": room_id,
+            "is_story_quest": True,
+            "reward": {
+                "door_reveal": True,
+                "story_info": "The path forward reveals itself!",
+            },
+            "failure_penalty": {"hp_damage": 0, "hunger_damage": 0, "thirst_damage": 0},
+            "prerequisite_quest_id": None,
+            "portrait_prompt": None,
+            "profile_image": None,
+        }
+        giver_npc = next((n for n in npc_pool if n["id"] == dr_giver_id), None)
+        if giver_npc and not giver_npc.get("quest_id"):
+            giver_npc["quest_id"] = door_reveal_quest["id"]
+        quest_list.append(door_reveal_quest)
         quest_id_counter += 1
 
     quest_bar.close()

--- a/src/generate/pipeline.py
+++ b/src/generate/pipeline.py
@@ -892,9 +892,10 @@ def _generate_room(room_idx: int, num_rooms: int, story, room_dir: str,
             climax_event["loot_table"] = _generate_loot_table(all_item_ids, boss_level)
             climax_event["money_drop"] = [boss_level * 10, boss_level * 30]
         event_list.append(climax_event)
+        maze.gate_encounter_id = boss_id
 
-    # --- Door placement (for non-final rooms) ---
-    if room_idx < num_rooms - 1:
+    # --- Door placement (rooms with a next room OR a climax boss) ---
+    if room_idx < num_rooms - 1 or (room_idx == num_rooms - 1 and num_rooms > 1):
         maze.place_door(player_start)
 
     # --- Quests ---
@@ -1066,9 +1067,11 @@ def _generate_room(room_idx: int, num_rooms: int, story, room_dir: str,
         quest_list.append(multi_quest)
         quest_id_counter += 1
 
-    # --- Door-reveal quest (one per non-final room) ---
-    if room_idx < num_rooms - 1 and npcs_for_quest and combat_events_for_quest:
-        dr_target = random.choice(combat_events_for_quest)
+    # --- Door-reveal quest (one per room that has a door) ---
+    climax_boss_id = maze.gate_encounter_id if room_idx == num_rooms - 1 else None
+    dr_candidates = [e for e in combat_events_for_quest if e["id"] != climax_boss_id]
+    if maze.door_position and npcs_for_quest and dr_candidates:
+        dr_target = random.choice(dr_candidates)
         dr_giver_id = random.choice(npcs_for_quest)["id"]
         door_reveal_quest = {
             "id": f"{event_id_prefix}q_{quest_id_counter:03d}",

--- a/src/systems/quest_manager.py
+++ b/src/systems/quest_manager.py
@@ -16,6 +16,7 @@ class QuestManager:
     def __init__(self, quests: dict[str, Quest], events: dict | None = None):
         self.quests = quests
         self.events = events or {}
+        self.door_reveal_callback = None
 
     # ------------------------------------------------------------------
     # Startup checks
@@ -161,6 +162,8 @@ class QuestManager:
                 msg += f" +{money} gold!"
             if quest.reward.story_info:
                 msg += f" {quest.reward.story_info}"
+            if quest.reward.door_reveal and self.door_reveal_callback:
+                self.door_reveal_callback()
 
         self._advance_multi_step(quest.id, player)
         return msg

--- a/tests/test_phase7_rooms.py
+++ b/tests/test_phase7_rooms.py
@@ -494,6 +494,137 @@ class TestDoorPlacement:
 # Config defaults
 # ---------------------------------------------------------------------------
 
+class TestClimaxBossVictory:
+    """Defeating the climax boss triggers the victory screen."""
+
+    def test_climax_boss_defeat_sets_victory(self):
+        from src.controllers.game_controller import GameController
+
+        combat_event = MagicMock()
+        combat_event.id = "climax_boss_001"
+        combat_event.resolved = False
+        combat_event.is_climax_boss = True
+        combat_event.is_gate = False
+        combat_event.monsters = []
+        combat_event.collect_loot = MagicMock(return_value=[])
+
+        gc = GameController.__new__(GameController)
+        gc.maze = MagicMock()
+        gc.player = PlayerCharacter(x=1, y=1)
+        gc.events = {"climax_boss_001": combat_event}
+        gc.dialogue_box = MagicMock()
+        gc.pending_action = None
+        gc.resolved_encounters = 0
+        gc.total_encounters = 1
+        gc.total_rooms = 3
+        gc.current_room = 2
+        gc.stats = {"monsters_killed": 0, "items_used": 0, "rooms_cleared": 0}
+        gc.quest_manager = MagicMock()
+
+        gc._handle_combat_victory(combat_event)
+
+        assert gc.pending_action == "victory"
+
+    def test_regular_combat_does_not_set_victory(self):
+        from src.controllers.game_controller import GameController
+
+        combat_event = MagicMock()
+        combat_event.id = "evt_001"
+        combat_event.resolved = False
+        combat_event.is_climax_boss = False
+        combat_event.is_gate = False
+        combat_event.monsters = []
+        combat_event.collect_loot = MagicMock(return_value=[])
+
+        gc = GameController.__new__(GameController)
+        gc.maze = MagicMock()
+        gc.maze.door_position = None
+        gc.maze.door_revealed = False
+        gc.player = PlayerCharacter(x=1, y=1)
+        gc.events = {"evt_001": combat_event}
+        gc.dialogue_box = MagicMock()
+        gc.pending_action = None
+        gc.resolved_encounters = 0
+        gc.total_encounters = 5
+        gc.total_rooms = 3
+        gc.current_room = 2
+        gc.item_message_active = False
+        gc.stats = {"monsters_killed": 0, "items_used": 0, "rooms_cleared": 0}
+        gc.quest_manager = MagicMock()
+
+        gc._handle_combat_victory(combat_event)
+
+        assert gc.pending_action is None
+
+
+class TestQuestDoorReveal:
+    """Quest with door_reveal=True calls reveal_door_from_quest."""
+
+    def test_quest_door_reveal_triggers_callback(self):
+        from src.systems.quest_manager import QuestManager
+        from src.models.quest import Quest, QuestReward
+
+        quest = Quest(
+            id="q_dr",
+            type="combat",
+            title="Clear the Path",
+            description="Defeat the monster",
+            giver_npc_id=100,
+            reward=QuestReward(door_reveal=True, story_info="Path revealed!"),
+        )
+        player = PlayerCharacter(x=1, y=1)
+        player.active_quests.append("q_dr")
+
+        qm = QuestManager({"q_dr": quest}, {})
+        callback = MagicMock()
+        qm.door_reveal_callback = callback
+
+        qm.complete_quest(quest, player)
+
+        callback.assert_called_once()
+        assert quest.status == "completed"
+
+    def test_quest_without_door_reveal_no_callback(self):
+        from src.systems.quest_manager import QuestManager
+        from src.models.quest import Quest, QuestReward
+
+        quest = Quest(
+            id="q_no_dr",
+            type="combat",
+            title="Just Kill",
+            description="Defeat the monster",
+            giver_npc_id=100,
+            reward=QuestReward(door_reveal=False),
+        )
+        player = PlayerCharacter(x=1, y=1)
+        player.active_quests.append("q_no_dr")
+
+        qm = QuestManager({"q_no_dr": quest}, {})
+        callback = MagicMock()
+        qm.door_reveal_callback = callback
+
+        qm.complete_quest(quest, player)
+
+        callback.assert_not_called()
+
+    def test_door_reveal_wired_in_game_controller(self):
+        """QuestManager gets the callback when GameController sets it up."""
+        from src.systems.quest_manager import QuestManager
+        from src.controllers.game_controller import GameController
+
+        gc = GameController.__new__(GameController)
+        gc.maze = MagicMock()
+        gc.player = PlayerCharacter(x=1, y=1)
+        gc.events = {}
+        gc.quests = {}
+        gc.dialogue_box = MagicMock()
+        gc.quest_manager = QuestManager(gc.quests, gc.events)
+        gc.quest_manager.door_reveal_callback = gc.reveal_door_from_quest
+
+        assert gc.quest_manager.door_reveal_callback is not None
+        assert gc.quest_manager.door_reveal_callback == gc.reveal_door_from_quest
+
+
 class TestConfig:
     def test_num_rooms_default(self):
         from config import NUM_ROOMS

--- a/tests/test_phase7_rooms.py
+++ b/tests/test_phase7_rooms.py
@@ -88,12 +88,14 @@ def player_with_class(warrior_class):
     return p
 
 
-def _make_mock_event(event_id="evt_001", resolved=False, is_gate=False):
+def _make_mock_event(event_id="evt_001", resolved=False, is_gate=False,
+                     is_climax_boss=False):
     """Create a mock event object for testing."""
     evt = MagicMock()
     evt.id = event_id
     evt.resolved = resolved
     evt.is_gate = is_gate
+    evt.is_climax_boss = is_climax_boss
     evt.type = "combat"
     return evt
 
@@ -497,37 +499,55 @@ class TestDoorPlacement:
 class TestClimaxBossVictory:
     """Defeating the climax boss triggers the victory screen."""
 
-    def test_climax_boss_defeat_sets_victory(self):
+    def _make_gc(self, events=None, current_room=2, total_rooms=3):
         from src.controllers.game_controller import GameController
-
-        combat_event = MagicMock()
-        combat_event.id = "climax_boss_001"
-        combat_event.resolved = False
-        combat_event.is_climax_boss = True
-        combat_event.is_gate = False
-        combat_event.monsters = []
-        combat_event.collect_loot = MagicMock(return_value=[])
-
         gc = GameController.__new__(GameController)
         gc.maze = MagicMock()
+        gc.maze.door_position = None
+        gc.maze.door_revealed = False
         gc.player = PlayerCharacter(x=1, y=1)
-        gc.events = {"climax_boss_001": combat_event}
+        gc.events = events or {}
         gc.dialogue_box = MagicMock()
         gc.pending_action = None
         gc.resolved_encounters = 0
-        gc.total_encounters = 1
-        gc.total_rooms = 3
-        gc.current_room = 2
+        gc.total_encounters = 5
+        gc.total_rooms = total_rooms
+        gc.current_room = current_room
+        gc.gate_cleared = False
+        gc.item_message_active = False
         gc.stats = {"monsters_killed": 0, "items_used": 0, "rooms_cleared": 0}
         gc.quest_manager = MagicMock()
+        return gc
 
+    def _make_climax_event(self):
+        evt = MagicMock()
+        evt.id = "climax_boss_001"
+        evt.resolved = False
+        evt.is_climax_boss = True
+        evt.is_gate = False
+        evt.monsters = []
+        evt.collect_loot = MagicMock(return_value=[])
+        return evt
+
+    def test_climax_boss_defeat_sets_victory(self):
+        combat_event = self._make_climax_event()
+        gc = self._make_gc({"climax_boss_001": combat_event})
         gc._handle_combat_victory(combat_event)
-
         assert gc.pending_action == "victory"
 
-    def test_regular_combat_does_not_set_victory(self):
-        from src.controllers.game_controller import GameController
+    def test_climax_boss_increments_resolved_encounters(self):
+        combat_event = self._make_climax_event()
+        gc = self._make_gc({"climax_boss_001": combat_event})
+        gc._handle_combat_victory(combat_event)
+        assert gc.resolved_encounters == 1
 
+    def test_climax_boss_sets_gate_cleared(self):
+        combat_event = self._make_climax_event()
+        gc = self._make_gc({"climax_boss_001": combat_event})
+        gc._handle_combat_victory(combat_event)
+        assert gc.gate_cleared is True
+
+    def test_regular_combat_does_not_set_victory(self):
         combat_event = MagicMock()
         combat_event.id = "evt_001"
         combat_event.resolved = False
@@ -536,25 +556,42 @@ class TestClimaxBossVictory:
         combat_event.monsters = []
         combat_event.collect_loot = MagicMock(return_value=[])
 
-        gc = GameController.__new__(GameController)
-        gc.maze = MagicMock()
-        gc.maze.door_position = None
-        gc.maze.door_revealed = False
-        gc.player = PlayerCharacter(x=1, y=1)
-        gc.events = {"evt_001": combat_event}
-        gc.dialogue_box = MagicMock()
-        gc.pending_action = None
-        gc.resolved_encounters = 0
-        gc.total_encounters = 5
-        gc.total_rooms = 3
-        gc.current_room = 2
-        gc.item_message_active = False
-        gc.stats = {"monsters_killed": 0, "items_used": 0, "rooms_cleared": 0}
-        gc.quest_manager = MagicMock()
-
+        gc = self._make_gc({"evt_001": combat_event})
         gc._handle_combat_victory(combat_event)
-
         assert gc.pending_action is None
+
+    def test_climax_boss_excluded_from_total_encounters(self):
+        """Climax boss should not inflate the 40% reveal denominator."""
+
+        regular = MagicMock()
+        regular.is_gate = False
+        regular.is_climax_boss = False
+        regular.resolved = False
+
+        boss = MagicMock()
+        boss.is_gate = False
+        boss.is_climax_boss = True
+        boss.resolved = False
+
+        gc = self._make_gc()
+        gc.events = {"e1": regular, "e2": regular, "boss": boss}
+        gc._count_total_encounters()
+
+        assert gc.total_encounters == 2
+
+    def test_signal_room_transition_final_room_sets_victory(self):
+        """Transitioning in the final room should trigger victory, not room_transition."""
+        gc = self._make_gc(current_room=2, total_rooms=3)
+        gc.quests = {}
+        gc._signal_room_transition()
+        assert gc.pending_action == "victory"
+
+    def test_signal_room_transition_non_final_room(self):
+        """Transitioning in a non-final room should trigger room_transition."""
+        gc = self._make_gc(current_room=0, total_rooms=3)
+        gc.quests = {}
+        gc._signal_room_transition()
+        assert gc.pending_action == "room_transition"
 
 
 class TestQuestDoorReveal:


### PR DESCRIPTION
## Summary
- Generate a climax boss encounter in the final room using `story.final_boss_name`, marked with `is_climax_boss: True` and scaled at 2.5x HP
- Defeating the climax boss sets `pending_action = "victory"`, triggering the VictoryView
- Wire `QuestManager.complete_quest()` to call `reveal_door_from_quest()` when a quest reward has `door_reveal: True`
- Generate one door-reveal combat quest per non-final room as an alternative to the 40% encounter threshold
- 28/28 Phase 7 tests pass (5 new: climax boss victory, quest door reveal callback, wiring)

## Test plan
- [x] `test_climax_boss_defeat_sets_victory` — defeating climax boss sets `pending_action = "victory"`
- [x] `test_regular_combat_does_not_set_victory` — normal combat does not trigger victory
- [x] `test_quest_door_reveal_triggers_callback` — quest with `door_reveal=True` calls the callback
- [x] `test_quest_without_door_reveal_no_callback` — quest without `door_reveal` does not call callback
- [x] `test_door_reveal_wired_in_game_controller` — GameController wires the callback on QuestManager