### PR TITLE
Phase 9: Tutorial, story screen, game over portrait, combat record

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,6 +35,8 @@ from src.views.load_game_view import LoadGameView
 from src.views.pause_view import PauseView
 from src.views.gameover_view import GameOverView
 from src.views.menu_view import MenuView
+from src.views.tutorial_view import TutorialView
+from src.views.story_view import StoryView
 from src.systems import save_manager
 from src.systems.fog_of_war import FogOfWar
 from src.models.time import DayNightCycle
@@ -309,9 +311,11 @@ def main():
     gameover_view = None
     victory_view = None
     menu_view = None
+    tutorial_view = None
+    story_view = None
 
     def _handle_start() -> str | None:
-        nonlocal class_select_view, load_game_view, load_source
+        nonlocal class_select_view, load_game_view, load_source, tutorial_view
         start_view.has_saves = _cached_has_saves
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
@@ -331,6 +335,10 @@ def main():
                     load_game_view = LoadGameView(screen, font, saves)
                     load_source = "start"
                     screen_ctrl.replace(ScreenState.LOAD_GAME)
+                    return None
+                if action == "tutorial":
+                    tutorial_view = TutorialView(screen, font)
+                    screen_ctrl.push(ScreenState.TUTORIAL)
                     return None
                 if action == "config":
                     screen_ctrl.replace(ScreenState.CONFIG)
@@ -425,7 +433,7 @@ def main():
         nonlocal game_controller, gameplay_start_time, player_menu_view
         nonlocal load_game_view, load_source, current_room_index
         nonlocal pause_view, gameover_view, menu_view
-        nonlocal room_intro_view, level_up_view, game_stats, victory_view
+        nonlocal room_intro_view, level_up_view, game_stats, victory_view, story_view
 
         if game_controller is None:
             game_controller = setup_game(screen, font, player_name, selected_class,
@@ -457,10 +465,35 @@ def main():
             screen_ctrl.push(ScreenState.PLAYER_MENU)
             return None
 
+        if result == "open_story":
+            story = registry.get_story()
+            room_beat = ""
+            room_name = ""
+            if story:
+                beat = next(
+                    (b for b in story.beats
+                     if b.room_id == f"room_{current_room_index}"), None)
+                if beat:
+                    room_beat = beat.summary
+            if game_controller:
+                room_name = game_controller.maze.environment_name or ""
+            story_view = StoryView(
+                screen, font, story=story,
+                room_story_beat=room_beat, room_name=room_name,
+            )
+            screen_ctrl.push(ScreenState.STORY)
+            return None
+
         if result == "game_over":
+            go_portrait = None
+            if registry.manifest:
+                go_portrait = registry.manifest.get("gameover_portrait")
+            if not go_portrait:
+                go_portrait = game_controller.player.profile_image
             gameover_view = GameOverView(
                 screen, font, game_controller.player,
                 has_saves=_cached_has_saves,
+                portrait_path=go_portrait,
             )
             screen_ctrl.push(ScreenState.GAME_OVER)
             return None
@@ -809,8 +842,42 @@ def main():
         clock.tick(60)
         return None
 
+    def _handle_tutorial() -> str | None:
+        nonlocal tutorial_view
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                return "quit"
+            if event.type == pygame.KEYDOWN:
+                action = tutorial_view.handle_input(event)
+                if action == "back":
+                    screen_ctrl.pop()
+                    return None
+        tutorial_view.draw()
+        pygame.display.flip()
+        clock.tick(60)
+        return None
+
+    def _handle_story() -> str | None:
+        nonlocal story_view
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                return "quit"
+            if event.type == pygame.KEYDOWN:
+                action = story_view.handle_input(event)
+                if action == "back":
+                    screen_ctrl.pop()
+                    return None
+        if game_controller:
+            current_time = pygame.time.get_ticks()
+            game_controller.draw(current_time)
+        story_view.draw()
+        pygame.display.flip()
+        clock.tick(60)
+        return None
+
     screen_handlers: dict[ScreenState, callable] = {
         ScreenState.START: _handle_start,
+        ScreenState.TUTORIAL: _handle_tutorial,
         ScreenState.CONFIG: _handle_config,
         ScreenState.CLASS_SELECT: _handle_class_select,
         ScreenState.ROOM_INTRO: _handle_room_intro,
@@ -821,6 +888,7 @@ def main():
         ScreenState.GAME_OVER: _handle_game_over,
         ScreenState.LEVEL_UP: _handle_level_up,
         ScreenState.VICTORY: _handle_victory,
+        ScreenState.STORY: _handle_story,
     }
 
     running = True

--- a/src/controllers/combat_controller.py
+++ b/src/controllers/combat_controller.py
@@ -146,6 +146,7 @@ class CombatController:
         if attack_roll >= dc:
             damage = self.player.roll_weapon_damage()
             target.take_damage(damage)
+            self.player.combat_record["damage_dealt"] += damage
             msg = f"You hit {target.name} for {damage} damage! (roll {attack_roll} vs AC {dc})"
             if not target.is_alive:
                 msg += f" {target.name} is slain!"
@@ -195,6 +196,7 @@ class CombatController:
 
         msg = "Multi-Attack: " + " ".join(messages)
         self.log.append(msg)
+        self.player.combat_record["damage_dealt"] += total_damage
         self.player.tick_buffs()
         self.advance_turn()
         return {"success": True, "message": msg, "total_damage": total_damage}
@@ -292,6 +294,7 @@ class CombatController:
 
         msg = " ".join(messages)
         self.log.append(msg)
+        self.player.combat_record["damage_dealt"] += total_damage
         self.player.tick_buffs()
         self.advance_turn()
         return {"success": True, "message": msg, "total_damage": total_damage}
@@ -511,5 +514,6 @@ class CombatController:
         if attack_roll >= player_ac:
             damage = monster.roll_damage()
             self.player.health = max(0, self.player.health - damage)
+            self.player.combat_record["damage_taken"] += damage
             return damage
         return 0

--- a/src/controllers/game_controller.py
+++ b/src/controllers/game_controller.py
@@ -506,6 +506,11 @@ class GameController:
             self.pending_action = "open_full_menu"
             return
 
+        # B key opens story recap
+        if event.key == pygame.K_b:
+            self.pending_action = "open_story"
+            return
+
     # ------------------------------------------------------------------
     # Full Combat System (CombatController + CombatView)
     # ------------------------------------------------------------------
@@ -816,6 +821,7 @@ class GameController:
                 self.dialogue_box.combat_log = list(combat_event.combat_log)
 
                 if result["success"]:
+                    self.player.combat_record["combats_fled"] += 1
                     self.dialogue_box.set_combat_phase("fled")
                     return
 
@@ -914,8 +920,10 @@ class GameController:
 
         # Track stats
         if hasattr(combat_event, 'monsters'):
-            self.stats["monsters_killed"] += sum(
-                1 for m in combat_event.monsters if not m.is_alive)
+            killed = sum(1 for m in combat_event.monsters if not m.is_alive)
+            self.stats["monsters_killed"] += killed
+            self.player.combat_record["monsters_killed"] += killed
+        self.player.combat_record["combats_won"] += 1
         if not getattr(combat_event, 'is_gate', False):
             self.resolved_encounters += 1
             self._check_door_reveal()

--- a/src/controllers/screen_controller.py
+++ b/src/controllers/screen_controller.py
@@ -5,6 +5,7 @@ from enum import Enum
 
 class ScreenState(Enum):
     START = "start"
+    TUTORIAL = "tutorial"
     CONFIG = "config"
     CLASS_SELECT = "class_select"
     ROOM_INTRO = "room_intro"
@@ -19,6 +20,7 @@ class ScreenState(Enum):
     LEVEL_UP = "level_up"
     GAME_OVER = "game_over"
     VICTORY = "victory"
+    STORY = "story"
 
 
 class ScreenController:

--- a/src/generate/pipeline.py
+++ b/src/generate/pipeline.py
@@ -1300,6 +1300,14 @@ def generate_world():
             )
             rr["environment_portrait"] = portrait_path
 
+        # Game over portrait (dark/somber theme)
+        gameover_portrait_path = os.path.join("data/portraits", "game_over.png")
+        generate_and_save_image(
+            "a fallen hero in darkness, somber memorial scene, "
+            "dark fantasy pixel art, moody lighting, dramatic shadows",
+            gameover_portrait_path,
+        )
+
         # Legacy environment portrait (room 0)
         env_portrait_path = os.path.join("data/portraits", "environment.png")
         r0_env_portrait = room_results[0].get("environment_portrait")
@@ -1346,6 +1354,7 @@ def generate_world():
         "portraits_generated": portraits_generated,
         "player_portrait": player_portrait_path,
         "environment_portrait": env_portrait_path,
+        "gameover_portrait": gameover_portrait_path,
         "game_mode": GAME_MODE,
         "story_title": story.title,
         "faction_name": story.faction.name if story.faction else "",

--- a/src/models/player.py
+++ b/src/models/player.py
@@ -131,6 +131,16 @@ class PlayerCharacter(BaseModel):
     equipped_weapon: Optional[str] = None
     learned_spells: List[str] = Field(default_factory=list)
 
+    # --- Combat record ---
+    combat_record: Dict[str, int] = Field(default_factory=lambda: {
+        "monsters_killed": 0,
+        "damage_dealt": 0,
+        "damage_taken": 0,
+        "combats_won": 0,
+        "combats_fled": 0,
+    })
+    title: str = ""
+
     class Config:
         arbitrary_types_allowed = True
 

--- a/src/systems/save_manager.py
+++ b/src/systems/save_manager.py
@@ -58,6 +58,8 @@ def serialize_player(player) -> dict:
         "failed_quests": list(player.failed_quests),
         "learned_spells": list(player.learned_spells),
         "profile_image": player.profile_image,
+        "combat_record": dict(player.combat_record),
+        "title": player.title,
     }
 
     # Player class
@@ -139,6 +141,11 @@ def deserialize_player(data: dict):
         failed_quests=data.get("failed_quests", []),
         learned_spells=data.get("learned_spells", []),
         profile_image=data.get("profile_image"),
+        combat_record=data.get("combat_record", {
+            "monsters_killed": 0, "damage_dealt": 0, "damage_taken": 0,
+            "combats_won": 0, "combats_fled": 0,
+        }),
+        title=data.get("title", ""),
         inventory=inventory,
         abilities=abilities,
         spells=spells,

--- a/src/views/gameover_view.py
+++ b/src/views/gameover_view.py
@@ -1,5 +1,6 @@
 """Game over screen — displays death message, brief stats, and options."""
 
+import os
 import pygame
 from config import SCREEN_WIDTH, SCREEN_HEIGHT, BLACK
 
@@ -14,7 +15,7 @@ MENU_ITEMS = ["Load Game", "Quit to Start"]
 class GameOverView:
     """Game Over screen with brief stats summary and load/quit options."""
 
-    def __init__(self, screen, font, player, has_saves=False):
+    def __init__(self, screen, font, player, has_saves=False, portrait_path=None):
         self.screen = screen
         self.font = font
         self.title_font = pygame.font.Font(None, 64)
@@ -22,9 +23,23 @@ class GameOverView:
         self.player = player
         self.has_saves = has_saves
         self.selected_index = 0
+        self.bg_image = None
+
+        if portrait_path and os.path.exists(portrait_path):
+            try:
+                img = pygame.image.load(portrait_path)
+                self.bg_image = pygame.transform.scale(img, (SCREEN_WIDTH, SCREEN_HEIGHT))
+            except Exception:
+                pass
 
     def draw(self):
-        self.screen.fill(BLACK)
+        if self.bg_image:
+            self.screen.blit(self.bg_image, (0, 0))
+            overlay = pygame.Surface((SCREEN_WIDTH, SCREEN_HEIGHT), pygame.SRCALPHA)
+            overlay.fill((0, 0, 0, 160))
+            self.screen.blit(overlay, (0, 0))
+        else:
+            self.screen.fill(BLACK)
 
         # Title
         title = self.title_font.render("GAME OVER", True, TITLE_COLOR)

--- a/src/views/menu_view.py
+++ b/src/views/menu_view.py
@@ -243,6 +243,26 @@ class MenuView:
         self._stat_pair("Weapon", weapon_name, col2, y2)
         y2 += 22
         self._stat_pair("Gold", str(p.money), col2, y2)
+        y2 += 36
+
+        # Combat record
+        cr = p.combat_record
+        self._stat_line("-- Combat Record --", HEADER_COLOR, col2, y2)
+        y2 += 24
+        self._stat_pair("Monsters Killed", str(cr.get("monsters_killed", 0)), col2, y2)
+        y2 += 22
+        self._stat_pair("Combats Won", str(cr.get("combats_won", 0)), col2, y2)
+        y2 += 22
+        self._stat_pair("Combats Fled", str(cr.get("combats_fled", 0)), col2, y2)
+        y2 += 22
+        self._stat_pair("Damage Dealt", str(cr.get("damage_dealt", 0)), col2, y2)
+        y2 += 22
+        self._stat_pair("Damage Taken", str(cr.get("damage_taken", 0)), col2, y2)
+
+        # Player title (if earned)
+        if p.title:
+            y += 10
+            self._stat_line(f'Title: "{p.title}"', HIGHLIGHT_COLOR, col1, y)
 
     def _stat_line(self, text: str, color, x: int, y: int):
         surf = self.small_font.render(text, True, color)

--- a/src/views/start_view.py
+++ b/src/views/start_view.py
@@ -1,4 +1,4 @@
-"""Start screen — New Game, Load Game, Tutorial (stub), Config, Quit."""
+"""Start screen — New Game, Load Game, Tutorial, Config, Quit."""
 
 import pygame
 from config import SCREEN_WIDTH, SCREEN_HEIGHT, BLACK
@@ -58,6 +58,7 @@ class StartView:
             hint_text = {
                 "Start New Game": "Press Enter to begin",
                 "Load Game": "Continue a saved game",
+                "Tutorial": "View controls and mechanics",
                 "Config": "View and edit settings",
                 "Quit": "Exit the game",
             }.get(selected_item, "")
@@ -71,14 +72,12 @@ class StartView:
         item = MENU_ITEMS[index]
         if item == "Load Game" and not self.has_saves:
             return True
-        if item == "Tutorial":
-            return True
         return False
 
     def handle_input(self, event) -> str | None:
         """Process a keydown event. Returns an action string or None.
 
-        Actions: "new_game", "load_game", "config", "quit", or None.
+        Actions: "new_game", "load_game", "tutorial", "config", "quit", or None.
         """
         if event.key == pygame.K_UP:
             self.selected_index = (self.selected_index - 1) % len(MENU_ITEMS)
@@ -92,6 +91,8 @@ class StartView:
                 return "new_game"
             elif selected == "Load Game":
                 return "load_game"
+            elif selected == "Tutorial":
+                return "tutorial"
             elif selected == "Config":
                 return "config"
             elif selected == "Quit":

--- a/src/views/story_view.py
+++ b/src/views/story_view.py
@@ -1,0 +1,108 @@
+"""Quick story screen — overarching story summary + current room intro."""
+
+import pygame
+from config import SCREEN_WIDTH, SCREEN_HEIGHT, BLACK
+
+TITLE_COLOR = (220, 180, 60)
+TEXT_COLOR = (200, 200, 200)
+SECTION_COLOR = (180, 160, 80)
+HINT_COLOR = (120, 120, 120)
+
+
+class StoryView:
+    """Overlay showing the overarching story synopsis and current room context."""
+
+    def __init__(self, screen, font, story=None, room_story_beat="",
+                 room_name="", faction_name=""):
+        self.screen = screen
+        self.font = font
+        self.title_font = pygame.font.Font(None, 48)
+        self.small_font = pygame.font.Font(None, 24)
+
+        self.title = story.title if story else "The Story So Far"
+        self.synopsis = story.synopsis if story else "No story data available."
+        self.faction_name = faction_name or (
+            story.faction.name if story and story.faction else ""
+        )
+        self.faction_desc = (
+            story.faction.description if story and story.faction else ""
+        )
+        self.climax = story.climax if story else ""
+        self.room_story_beat = room_story_beat
+        self.room_name = room_name
+
+    def draw(self):
+        # Semi-transparent overlay
+        overlay = pygame.Surface((SCREEN_WIDTH, SCREEN_HEIGHT))
+        overlay.fill(BLACK)
+        overlay.set_alpha(210)
+        self.screen.blit(overlay, (0, 0))
+
+        y = 30
+
+        # Title
+        title_surf = self.title_font.render(self.title, True, TITLE_COLOR)
+        self.screen.blit(title_surf, ((SCREEN_WIDTH - title_surf.get_width()) // 2, y))
+        y += 50
+
+        # Synopsis
+        self._draw_section("Synopsis", y)
+        y += 24
+        y = self._draw_wrapped(self.synopsis, 60, y, SCREEN_WIDTH - 120)
+        y += 16
+
+        # Faction
+        if self.faction_name:
+            self._draw_section(f"Faction: {self.faction_name}", y)
+            y += 24
+            if self.faction_desc:
+                y = self._draw_wrapped(self.faction_desc, 60, y, SCREEN_WIDTH - 120)
+            y += 16
+
+        # What lies ahead
+        if self.climax:
+            self._draw_section("What Lies Ahead", y)
+            y += 24
+            y = self._draw_wrapped(self.climax, 60, y, SCREEN_WIDTH - 120)
+            y += 16
+
+        # Current room
+        if self.room_story_beat:
+            label = f"Current Area: {self.room_name}" if self.room_name else "Current Area"
+            self._draw_section(label, y)
+            y += 24
+            self._draw_wrapped(self.room_story_beat, 60, y, SCREEN_WIDTH - 120)
+
+        # Footer
+        hint = self.small_font.render("Press Esc or Enter to return", True, HINT_COLOR)
+        self.screen.blit(hint, ((SCREEN_WIDTH - hint.get_width()) // 2, SCREEN_HEIGHT - 30))
+
+    def _draw_section(self, text: str, y: int):
+        surf = self.small_font.render(text, True, SECTION_COLOR)
+        self.screen.blit(surf, (40, y))
+
+    def _draw_wrapped(self, text: str, x: int, y: int, max_w: int) -> int:
+        words = text.split()
+        lines = []
+        current = ""
+        for word in words:
+            test = f"{current} {word}".strip()
+            if self.small_font.size(test)[0] <= max_w:
+                current = test
+            else:
+                if current:
+                    lines.append(current)
+                current = word
+        if current:
+            lines.append(current)
+        for line in lines:
+            surf = self.small_font.render(line, True, TEXT_COLOR)
+            self.screen.blit(surf, (x, y))
+            y += self.small_font.get_linesize()
+        return y
+
+    def handle_input(self, event) -> str | None:
+        """Returns 'back' on Esc or Enter."""
+        if event.key in (pygame.K_ESCAPE, pygame.K_RETURN):
+            return "back"
+        return None

--- a/src/views/tutorial_view.py
+++ b/src/views/tutorial_view.py
@@ -1,0 +1,73 @@
+"""Tutorial screen — controls reference card accessible from the start menu."""
+
+import pygame
+from config import SCREEN_WIDTH, SCREEN_HEIGHT, BLACK
+from src.views.pause_view import CONTROLS_TEXT
+
+TITLE_COLOR = (220, 180, 60)
+TEXT_COLOR = (200, 200, 200)
+HINT_COLOR = (120, 120, 120)
+SECTION_COLOR = (180, 160, 80)
+
+
+class TutorialView:
+    """Full-screen controls reference card with keybindings and basic mechanics."""
+
+    def __init__(self, screen, font):
+        self.screen = screen
+        self.font = font
+        self.title_font = pygame.font.Font(None, 56)
+        self.small_font = pygame.font.Font(None, 24)
+
+    def draw(self):
+        self.screen.fill(BLACK)
+
+        # Title
+        title = self.title_font.render("Controls & Mechanics", True, TITLE_COLOR)
+        self.screen.blit(title, ((SCREEN_WIDTH - title.get_width()) // 2, 40))
+
+        # Controls reference (from pause_view)
+        y = 110
+        for line in CONTROLS_TEXT:
+            if not line:
+                y += 10
+                continue
+            # Section headers (lines ending with ':')
+            if line.endswith(":"):
+                color = SECTION_COLOR
+            else:
+                color = TEXT_COLOR
+            surf = self.small_font.render(line, True, color)
+            self.screen.blit(surf, (SCREEN_WIDTH // 2 - 160, y))
+            y += 24
+
+        # Additional mechanics section
+        y += 16
+        self._draw_section("Gameplay Tips:", y)
+        y += 28
+        tips = [
+            "Explore each room to find items, NPCs, and quests.",
+            "Keep hunger and thirst above 0 or you'll lose HP.",
+            "Talk to NPCs for quests, lore, and trading.",
+            "Clear encounters to unlock the gate to the next room.",
+            "Use M to open the full menu with stats and spells.",
+            "Press B during gameplay to review the story so far.",
+        ]
+        for tip in tips:
+            surf = self.small_font.render(tip, True, TEXT_COLOR)
+            self.screen.blit(surf, (SCREEN_WIDTH // 2 - 160, y))
+            y += 24
+
+        # Footer
+        hint = self.small_font.render("Press Esc or Enter to return", True, HINT_COLOR)
+        self.screen.blit(hint, ((SCREEN_WIDTH - hint.get_width()) // 2, SCREEN_HEIGHT - 40))
+
+    def _draw_section(self, text: str, y: int):
+        surf = self.small_font.render(text, True, SECTION_COLOR)
+        self.screen.blit(surf, (SCREEN_WIDTH // 2 - 160, y))
+
+    def handle_input(self, event) -> str | None:
+        """Returns 'back' on Esc or Enter."""
+        if event.key in (pygame.K_ESCAPE, pygame.K_RETURN):
+            return "back"
+        return None

--- a/tests/test_phase9_gaps.py
+++ b/tests/test_phase9_gaps.py
@@ -1,0 +1,268 @@
+"""Tests for Phase 9 gaps: Tutorial, Story, GameOver portrait, Combat record."""
+
+import sys
+import os
+import pytest
+import pygame
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.models.player import PlayerCharacter, PlayerClass, Stats
+from src.controllers.screen_controller import ScreenController, ScreenState
+from src.views.tutorial_view import TutorialView
+from src.views.story_view import StoryView
+from src.views.gameover_view import GameOverView
+from src.views.menu_view import MenuView
+from src.models.story import OverarchingStory, Faction
+import config as cfg
+
+
+@pytest.fixture(autouse=True)
+def init_pygame():
+    pygame.init()
+    yield
+    pygame.quit()
+
+
+@pytest.fixture
+def screen():
+    return pygame.Surface((cfg.SCREEN_WIDTH, cfg.SCREEN_HEIGHT))
+
+
+@pytest.fixture
+def font():
+    return pygame.font.SysFont(None, 24)
+
+
+def _make_player_with_class():
+    pc = PlayerClass(
+        name="Knight", archetype="warrior",
+        stats=Stats(STR=16, DEX=12, CON=14, INT=8, WIS=8, CHA=10, LUCK=10),
+    )
+    p = PlayerCharacter(x=0, y=0, name="TestHero")
+    p.player_class = pc
+    return p
+
+
+# ---------------------------------------------------------------------------
+# GAP 1: Tutorial View
+# ---------------------------------------------------------------------------
+
+class TestTutorialView:
+    def test_screen_state_exists(self):
+        assert hasattr(ScreenState, "TUTORIAL")
+        assert ScreenState.TUTORIAL.value == "tutorial"
+
+    def test_draw_no_crash(self, screen, font):
+        view = TutorialView(screen, font)
+        view.draw()
+
+    def test_esc_returns_back(self, screen, font):
+        view = TutorialView(screen, font)
+        event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_ESCAPE)
+        assert view.handle_input(event) == "back"
+
+    def test_enter_returns_back(self, screen, font):
+        view = TutorialView(screen, font)
+        event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RETURN)
+        assert view.handle_input(event) == "back"
+
+    def test_other_keys_return_none(self, screen, font):
+        view = TutorialView(screen, font)
+        event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_a)
+        assert view.handle_input(event) is None
+
+    def test_tutorial_pushed_from_start(self):
+        sc = ScreenController(ScreenState.START)
+        sc.push(ScreenState.TUTORIAL)
+        assert sc.state == ScreenState.TUTORIAL
+        sc.pop()
+        assert sc.state == ScreenState.START
+
+
+# ---------------------------------------------------------------------------
+# GAP 2: Story View
+# ---------------------------------------------------------------------------
+
+class TestStoryView:
+    def test_screen_state_exists(self):
+        assert hasattr(ScreenState, "STORY")
+        assert ScreenState.STORY.value == "story"
+
+    def test_draw_no_crash_no_story(self, screen, font):
+        view = StoryView(screen, font, story=None)
+        view.draw()
+
+    def test_draw_with_story(self, screen, font):
+        story = OverarchingStory(
+            title="The Dark Rift",
+            synopsis="Evil grows in the land.",
+            faction=Faction(name="Shadow Cult", description="They worship darkness."),
+            climax="A showdown at the rift.",
+        )
+        view = StoryView(screen, font, story=story, room_story_beat="A cold wind blows.",
+                         room_name="The Crypt")
+        view.draw()
+
+    def test_esc_returns_back(self, screen, font):
+        view = StoryView(screen, font, story=None)
+        event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_ESCAPE)
+        assert view.handle_input(event) == "back"
+
+    def test_enter_returns_back(self, screen, font):
+        view = StoryView(screen, font, story=None)
+        event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RETURN)
+        assert view.handle_input(event) == "back"
+
+    def test_other_keys_return_none(self, screen, font):
+        view = StoryView(screen, font, story=None)
+        event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_a)
+        assert view.handle_input(event) is None
+
+
+# ---------------------------------------------------------------------------
+# GAP 3: GameOver Portrait
+# ---------------------------------------------------------------------------
+
+class TestGameOverPortrait:
+    def test_gameover_accepts_portrait_path(self, screen, font):
+        player = _make_player_with_class()
+        player.completed_quests = []
+        player.failed_quests = []
+        view = GameOverView(screen, font, player, portrait_path=None)
+        assert view.bg_image is None
+
+    def test_gameover_missing_portrait_fallback(self, screen, font):
+        player = _make_player_with_class()
+        player.completed_quests = []
+        player.failed_quests = []
+        view = GameOverView(screen, font, player, portrait_path="/nonexistent/path.png")
+        assert view.bg_image is None
+
+    def test_gameover_draw_no_crash_without_portrait(self, screen, font):
+        player = _make_player_with_class()
+        player.completed_quests = []
+        player.failed_quests = []
+        view = GameOverView(screen, font, player, portrait_path=None)
+        view.draw()
+
+    def test_gameover_draw_no_crash_with_portrait(self, screen, font, tmp_path):
+        # Create a small test image
+        img = pygame.Surface((100, 100))
+        img.fill((128, 0, 0))
+        img_path = str(tmp_path / "test_portrait.png")
+        pygame.image.save(img, img_path)
+
+        player = _make_player_with_class()
+        player.completed_quests = []
+        player.failed_quests = []
+        view = GameOverView(screen, font, player, portrait_path=img_path)
+        assert view.bg_image is not None
+        view.draw()
+
+
+# ---------------------------------------------------------------------------
+# GAP 4: Combat Record + Title
+# ---------------------------------------------------------------------------
+
+class TestCombatRecord:
+    def test_default_combat_record(self):
+        p = PlayerCharacter(x=0, y=0)
+        assert p.combat_record == {
+            "monsters_killed": 0,
+            "damage_dealt": 0,
+            "damage_taken": 0,
+            "combats_won": 0,
+            "combats_fled": 0,
+        }
+
+    def test_default_title_empty(self):
+        p = PlayerCharacter(x=0, y=0)
+        assert p.title == ""
+
+    def test_combat_record_mutable(self):
+        p = PlayerCharacter(x=0, y=0)
+        p.combat_record["monsters_killed"] += 5
+        p.combat_record["damage_dealt"] += 120
+        p.combat_record["damage_taken"] += 40
+        p.combat_record["combats_won"] += 3
+        p.combat_record["combats_fled"] += 1
+        assert p.combat_record["monsters_killed"] == 5
+        assert p.combat_record["combats_won"] == 3
+
+    def test_combat_record_independent_per_player(self):
+        p1 = PlayerCharacter(x=0, y=0)
+        p2 = PlayerCharacter(x=1, y=1)
+        p1.combat_record["monsters_killed"] = 10
+        assert p2.combat_record["monsters_killed"] == 0
+
+    def test_title_set(self):
+        p = PlayerCharacter(x=0, y=0, title="Dragon Slayer")
+        assert p.title == "Dragon Slayer"
+
+    def test_stats_tab_shows_combat_record(self, screen, font):
+        player = _make_player_with_class()
+        player.active_quests = []
+        player.completed_quests = ["q1"]
+        player.failed_quests = []
+        player.combat_record["monsters_killed"] = 7
+        player.combat_record["combats_won"] = 3
+        player.combat_record["combats_fled"] = 1
+        player.combat_record["damage_dealt"] = 200
+        player.combat_record["damage_taken"] = 50
+        player.title = "Champion"
+
+        view = MenuView(screen, font, player)
+        view.active_tab = 1
+        view.draw()  # Should not crash
+
+    def test_stats_tab_no_title(self, screen, font):
+        player = _make_player_with_class()
+        player.active_quests = []
+        player.completed_quests = []
+        player.failed_quests = []
+        player.title = ""
+
+        view = MenuView(screen, font, player)
+        view.active_tab = 1
+        view.draw()  # Should not crash
+
+
+# ---------------------------------------------------------------------------
+# Combat Record Serialization
+# ---------------------------------------------------------------------------
+
+class TestCombatRecordSerialization:
+    def test_serialize_combat_record(self):
+        from src.systems.save_manager import serialize_player
+        p = _make_player_with_class()
+        p.initialize_inventory()
+        p.combat_record["monsters_killed"] = 5
+        p.combat_record["damage_dealt"] = 100
+        p.title = "Veteran"
+
+        data = serialize_player(p)
+        assert data["combat_record"]["monsters_killed"] == 5
+        assert data["combat_record"]["damage_dealt"] == 100
+        assert data["title"] == "Veteran"
+
+    def test_deserialize_combat_record(self):
+        from src.systems.save_manager import serialize_player, deserialize_player
+        p = _make_player_with_class()
+        p.initialize_inventory()
+        p.combat_record["combats_won"] = 3
+        p.combat_record["combats_fled"] = 1
+        p.title = "Hero"
+
+        data = serialize_player(p)
+        restored = deserialize_player(data)
+        assert restored.combat_record["combats_won"] == 3
+        assert restored.combat_record["combats_fled"] == 1
+        assert restored.title == "Hero"
+
+    def test_deserialize_missing_combat_record(self):
+        from src.systems.save_manager import deserialize_player
+        data = {"x": 0, "y": 0, "name": "Test"}
+        restored = deserialize_player(data)
+        assert restored.combat_record["monsters_killed"] == 0
+        assert restored.title == ""

--- a/tests/test_screens.py
+++ b/tests/test_screens.py
@@ -90,11 +90,11 @@ def test_start_view_load_game_disabled(screen, font):
     assert view.handle_input(event) is None
 
 
-def test_start_view_tutorial_disabled(screen, font):
+def test_start_view_tutorial_enabled(screen, font):
     view = StartView(screen, font)
     view.selected_index = MENU_ITEMS.index("Tutorial")
     event = pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RETURN)
-    assert view.handle_input(event) is None
+    assert view.handle_input(event) == "tutorial"
 
 
 def test_start_view_quit(screen, font):


### PR DESCRIPTION
## Summary
- **Tutorial screen**: Created `TutorialView` with controls reference card and gameplay tips. Enabled the Tutorial option in the start menu with TUTORIAL ScreenState.
- **Quick story screen**: Created `StoryView` showing overarching story synopsis, faction info, and current room context. Accessible via B key during gameplay with STORY ScreenState.
- **Game over portrait**: Added portrait support to `GameOverView` with dark overlay for readability. Pipeline generates a somber `game_over.png` during world gen. Falls back gracefully if no portrait exists.
- **Combat record & title**: Added `combat_record` dict (monsters killed, damage dealt/taken, combats won/fled) and `title` field to `PlayerCharacter`. Tracked in combat controller, displayed in stats tab, persisted in save/load.

26 new tests added. 818 total tests passing. Ruff clean.

## Test plan
- [x] All 818 tests pass
- [x] Ruff check passes on all changed files
- [x] New test file `test_phase9_gaps.py` covers all 4 gaps
- [x] Existing `test_screens.py` updated (tutorial enabled, not disabled)
- [x] Save/load roundtrip tested for combat_record and title fields