### PR TITLE
Phase 8: Night monsters, time-gated events/NPCs, real-time day cycle

### DIFF
--- a/src/controllers/game_controller.py
+++ b/src/controllers/game_controller.py
@@ -5,13 +5,14 @@ from src.views.combat_view import CombatView
 from src.views.gameplay_view import GameView
 from src.views.shop_view import ShopView
 from src.models.npc import RandomNPC, AggressiveNPC, MerchantNPC
-from src.models.time import DayNightCycle
+from src.models.time import DayNightCycle, TimePeriod
 from src.systems.fog_of_war import FogOfWar
 from src.systems.day_night import (
     apply_rest, apply_combat_rest, player_has_torch,
     consume_torch_use, is_event_active_at_time, is_npc_available,
     get_night_overlay_alpha,
 )
+from src.models.monster import generate_night_variant
 from src.registry import registry
 from src.utils.conversation_utils import has_dialogue_choices
 from src.systems.survival import SurvivalSystem
@@ -248,8 +249,7 @@ class GameController:
         return None
 
     def after_move_check(self):
-        # Advance time on movement
-        self.day_night.advance(1)
+        # Time advances via real-time update() in the main loop
         # Update fog of war
         self._update_fog()
         # Consume torch use only on movement (not rest or startup)
@@ -290,6 +290,12 @@ class GameController:
         from src.models.weapon import STARTER_WEAPONS
         if self.player.weapon is None and self.player.player_class:
             self.player.weapon = STARTER_WEAPONS.get(self.player.player_class.archetype)
+
+        # At night, upgrade non-night-only monsters to nightstalker variants
+        if self.day_night.current_period == TimePeriod.NIGHT:
+            for i, monster in enumerate(combat_event.monsters):
+                if monster.time_availability == "always":
+                    combat_event.monsters[i] = generate_night_variant(monster)
 
         self.combat_event = combat_event
         self.combat_controller = CombatController(self.player, list(combat_event.monsters))
@@ -1076,7 +1082,10 @@ class GameController:
             self.item_detail_active = True
 
     def update(self, current_time):
-        """Update game logic (NPC movement, etc.)"""
+        """Update game logic (NPC movement, real-time day/night, etc.)"""
+        # Advance day/night cycle with real time
+        self.day_night.update(current_time)
+
         if self.dialogue_box.generating:
             self.dialogue_box.check_generation()
 

--- a/src/generate/checker.py
+++ b/src/generate/checker.py
@@ -185,3 +185,89 @@ class EventChecker(BaseChecker):
                 issues.append("Puzzle has no walk-away option")
 
         return CheckResult(passed=len(issues) == 0, issues=issues, data=data)
+
+
+class ItemChecker(BaseChecker):
+    """Checks generated item data for required fields and valid categories."""
+
+    VALID_CATEGORIES = {"food", "drink", "tool", "weapon", "spell_scroll"}
+
+    def check(self, data: dict, context: dict | None = None) -> CheckResult:
+        issues: list[str] = []
+
+        if not data.get("name"):
+            issues.append("Item missing name")
+
+        category = data.get("category", "")
+        if category not in self.VALID_CATEGORIES:
+            issues.append(f"Invalid item category '{category}'")
+
+        stats = data.get("item_stats", {})
+        if not stats:
+            issues.append("Item missing item_stats")
+
+        if category == "weapon":
+            if not stats.get("attack_dice"):
+                issues.append("Weapon missing attack_dice")
+            if not stats.get("stat_modifier"):
+                issues.append("Weapon missing stat_modifier")
+        elif category == "tool":
+            if not stats.get("attribute"):
+                issues.append("Tool missing attribute")
+        elif category in ("food", "drink"):
+            if stats.get("nutrition_value", 0) == 0 and stats.get("hydration_value", 0) == 0:
+                if category == "food":
+                    issues.append("Food item has no nutrition_value")
+                else:
+                    issues.append("Drink item has no hydration_value")
+
+        return CheckResult(passed=len(issues) == 0, issues=issues, data=data)
+
+
+class NPCChecker(BaseChecker):
+    """Checks NPC data for required personality and identity fields."""
+
+    REQUIRED_FIELDS = {"name", "type", "environment"}
+
+    def check(self, data: dict, context: dict | None = None) -> CheckResult:
+        issues: list[str] = []
+
+        missing = self.REQUIRED_FIELDS - set(data.keys())
+        if missing:
+            issues.append(f"NPC missing fields: {', '.join(sorted(missing))}")
+
+        if not data.get("name"):
+            issues.append("NPC has empty name")
+
+        npc_type = data.get("type", "")
+        valid_types = {"StaticNPC", "RandomNPC", "AggressiveNPC", "MerchantNPC"}
+        if npc_type and npc_type not in valid_types:
+            issues.append(f"Invalid NPC type '{npc_type}'")
+
+        if not data.get("personality"):
+            issues.append("NPC missing personality trait")
+
+        return CheckResult(passed=len(issues) == 0, issues=issues, data=data)
+
+
+class MonsterChecker(BaseChecker):
+    """Checks monster data for combat-required fields."""
+
+    def check(self, data: dict, context: dict | None = None) -> CheckResult:
+        issues: list[str] = []
+
+        if not data.get("name"):
+            issues.append("Monster missing name")
+
+        hp = data.get("hp", 0)
+        if hp <= 0:
+            issues.append(f"Monster has invalid hp: {hp}")
+
+        if not data.get("attack_dice"):
+            issues.append("Monster missing attack_dice")
+
+        ac = data.get("ac", 0)
+        if ac <= 0:
+            issues.append(f"Monster has invalid ac: {ac}")
+
+        return CheckResult(passed=len(issues) == 0, issues=issues, data=data)

--- a/src/generate/generator.py
+++ b/src/generate/generator.py
@@ -1,1 +1,319 @@
-"""Base Generator class for content generation. Populated in later phases."""
+"""Base Generator class and concrete generators for content generation.
+
+Each generator encapsulates the Gen -> Check -> Validate chain for a
+specific content type.  Generators read the WorldBible for lore context
+so that generated content is narratively coherent.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+
+from src.generate.checker import (
+    BaseChecker, EventChecker, ItemChecker, NPCChecker, QuestChecker,
+)
+from src.generate.validator import (
+    BaseValidator, EventValidator, ItemValidator, NPCValidator, QuestValidator, ValidationReport,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_RETRIES = 3
+
+
+@dataclass
+class GenerationResult:
+    """Outcome of a full Gen -> Check -> Validate cycle."""
+    content: object
+    passed: bool
+    used_fallback: bool = False
+    attempts: int = 1
+    issues: list[str] = field(default_factory=list)
+
+
+class BaseGenerator(ABC):
+    """Abstract generator with built-in Gen -> Check -> Validate chain.
+
+    Subclasses implement:
+    - ``_generate()``: produce raw content from LLM or static fallback
+    - ``_fallback()``: return safe static content when retries are exhausted
+    - ``checker``: a BaseChecker instance for structural checking
+    - ``validator``: a BaseValidator instance for logic validation
+    """
+
+    checker: BaseChecker | None = None
+    validator: BaseValidator | None = None
+    max_retries: int = MAX_RETRIES
+
+    @abstractmethod
+    def _generate(self, context: dict, feedback: list[str] | None = None) -> object:
+        """Produce raw content. *feedback* contains reasons from prior failures."""
+        ...
+
+    @abstractmethod
+    def _fallback(self, context: dict) -> object:
+        """Return safe fallback content when all retries are exhausted."""
+        ...
+
+    def generate(
+        self,
+        context: dict,
+        report: ValidationReport | None = None,
+        label: str = "content",
+    ) -> GenerationResult:
+        """Run the full Gen -> Check -> Validate chain with retries."""
+        feedback: list[str] | None = None
+        all_issues: list[str] = []
+
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                content = self._generate(context, feedback=feedback)
+            except Exception as e:
+                logger.warning("[%s] attempt %d generation error: %s", label, attempt, e)
+                feedback = [str(e)]
+                all_issues.append(str(e))
+                if report:
+                    report.add_major(
+                        f"{label} generation error attempt {attempt}: {e}",
+                        phase=label,
+                    )
+                continue
+
+            # --- Check phase ---
+            issues: list[str] = []
+            if self.checker is not None:
+                check_result = self.checker.check(content, context)
+                if not check_result.passed:
+                    issues.extend(check_result.issues)
+                if check_result.data is not None:
+                    content = check_result.data
+
+            # --- Validate phase ---
+            if self.validator is not None and not issues:
+                val_result = self.validator.validate(content, context)
+                if not val_result.passed:
+                    issues.extend(val_result.reasons)
+                if val_result.data is not None:
+                    content = val_result.data
+
+            if not issues:
+                logger.info("[%s] passed on attempt %d.", label, attempt)
+                return GenerationResult(
+                    content=content, passed=True, attempts=attempt,
+                )
+
+            logger.warning("[%s] attempt %d issues: %s", label, attempt, issues)
+            all_issues.extend(issues)
+            feedback = issues
+            if report:
+                report.add_major(
+                    f"{label} failed validation attempt {attempt}: {'; '.join(issues)}",
+                    phase=label,
+                )
+
+        # Exhausted retries — use fallback
+        logger.warning("[%s] exhausted %d retries, using fallback.", label, self.max_retries)
+        fallback = self._fallback(context)
+        if report:
+            report.add_warning(
+                f"{label} used fallback after {self.max_retries} retries",
+                phase=label,
+            )
+        return GenerationResult(
+            content=fallback, passed=True, used_fallback=True,
+            attempts=self.max_retries, issues=all_issues,
+        )
+
+
+class EventGenerator(BaseGenerator):
+    """Generates events (combat/puzzle/event) with check + validate."""
+
+    def __init__(self):
+        self.checker = EventChecker()
+        self.validator = EventValidator()
+
+    def _generate(self, context: dict, feedback: list[str] | None = None) -> dict:
+        from src.generate.generators.llm_primitives import generate_event_primitive
+        env_ctx = {"environment": {
+            "type": context.get("env_type", "forest"),
+            "name": context.get("env_name", "Unknown"),
+        }}
+        if feedback:
+            env_ctx["retry_feedback"] = "; ".join(feedback)
+        if context.get("bible_context"):
+            env_ctx["bible_context"] = context["bible_context"]
+        event_type = context.get("event_type", "combat")
+        result = generate_event_primitive(env_ctx, event_type)
+        if "error" in result:
+            raise ValueError(result["error"])
+        result.setdefault("type", event_type)
+        return result
+
+    def _fallback(self, context: dict) -> dict:
+        import random
+        event_type = context.get("event_type", "combat")
+        if event_type == "combat":
+            return {
+                "name": random.choice(["Goblin", "Giant Rat", "Skeleton", "Slime", "Bandit"]),
+                "description": "A hostile creature attacks!",
+                "type": "combat",
+                "difficulty": random.randint(2, 4),
+                "damage_type": random.choice(["health", "hunger", "thirst"]),
+                "damage_range": [5, 15],
+            }
+        return {
+            "name": random.choice(["Locked Chest", "Crumbling Bridge", "Strange Rune", "Trapped Door"]),
+            "description": "A mysterious obstacle blocks your path...",
+            "type": event_type,
+            "difficulty": random.randint(1, 3),
+            "choices": [
+                {"text": "Try to force through", "stat_check": "health", "dc": 12, "auto_success": False},
+                {"text": "Walk away", "auto_success": True},
+            ],
+        }
+
+
+class NPCGenerator(BaseGenerator):
+    """Generates NPC personality + greeting with check + validate."""
+
+    def __init__(self):
+        self.checker = NPCChecker()
+        self.validator = NPCValidator()
+
+    def _generate(self, context: dict, feedback: list[str] | None = None) -> dict:
+        from src.generate.generators.llm_primitives import (
+            generate_personality_primitive, generate_npc_convo,
+            generate_image_description,
+        )
+        env_type = context.get("env_type", "forest")
+        env_name = context.get("env_name", "Unknown")
+        npc_type = context.get("npc_type", "StaticNPC")
+
+        personality = generate_personality_primitive({
+            "environment": {"type": env_type, "name": env_name},
+        })
+        if "error" in personality:
+            raise ValueError(personality["error"])
+
+        greeting = generate_npc_convo(personality)
+        portrait_prompt = generate_image_description(personality)
+
+        return {
+            "name": personality.get("name", "Unknown"),
+            "type": npc_type,
+            "job": personality.get("job", "peasant"),
+            "personality": personality.get("personality", "stoic"),
+            "hobby": personality.get("hobby", "walking"),
+            "environment": env_type,
+            "environment_name": env_name,
+            "description": personality.get("description", ""),
+            "opening_greeting": greeting,
+            "portrait_prompt": portrait_prompt,
+        }
+
+    def _fallback(self, context: dict) -> dict:
+        import random
+        from src.data.world_data import NAMES, PERSONALITIES, JOBS, HOBBIES
+        env_type = context.get("env_type", "city")
+        return {
+            "name": random.choice(NAMES),
+            "type": context.get("npc_type", "StaticNPC"),
+            "job": random.choice(JOBS.get(env_type, JOBS["city"])),
+            "personality": random.choice(PERSONALITIES),
+            "hobby": random.choice(HOBBIES.get(env_type, HOBBIES["city"])),
+            "environment": env_type,
+            "environment_name": context.get("env_name", "Unknown"),
+            "description": "",
+            "opening_greeting": "Greetings, traveler.",
+            "portrait_prompt": "a fantasy character portrait, pixel art",
+        }
+
+
+class QuestGenerator(BaseGenerator):
+    """Generates quests with check + validate."""
+
+    def __init__(self):
+        self.checker = QuestChecker()
+        self.validator = QuestValidator()
+
+    def _generate(self, context: dict, feedback: list[str] | None = None) -> dict:
+        from src.generate.generators.llm_primitives import generate_quest_primitive
+        env_ctx = {"environment": {
+            "type": context.get("env_type", "forest"),
+            "name": context.get("env_name", "Unknown"),
+        }}
+        if feedback:
+            env_ctx["retry_feedback"] = "; ".join(feedback)
+        quest_type = context.get("quest_type", "fetch")
+        npcs = context.get("npcs", [])
+        items = context.get("items", [])
+        events = context.get("events", [])
+        result = generate_quest_primitive(env_ctx, npcs, items, events, quest_type)
+        if "error" in result:
+            raise ValueError(result["error"])
+        return result
+
+    def _fallback(self, context: dict) -> dict:
+        return {
+            "title": f"A {context.get('quest_type', 'fetch')} quest",
+            "description": "Complete this task for a reward.",
+        }
+
+
+class ItemGenerator(BaseGenerator):
+    """Generates environment-themed items with check + validate."""
+
+    def __init__(self):
+        self.checker = ItemChecker()
+        self.validator = ItemValidator()
+
+    def _generate(self, context: dict, feedback: list[str] | None = None) -> dict:
+        from src.generate.generators.llm_primitives import generate_item_primitive
+        env_ctx = {"environment": {
+            "type": context.get("env_type", "forest"),
+            "name": context.get("env_name", "Unknown"),
+        }}
+        room_level = context.get("room_level", 1)
+        result = generate_item_primitive(env_ctx, room_level)
+        if "error" in result:
+            raise ValueError(result["error"])
+        return result
+
+    def _fallback(self, context: dict) -> dict:
+        return {
+            "food": [{"name": "Bread", "nutrition_value": 15}],
+            "drink": [{"name": "Water", "hydration_value": 15}],
+            "tools": [{"name": "Hammer", "attribute": "bludgeon"}],
+            "weapons": [{"name": "Dagger", "attack_dice": "1d4", "stat_modifier": "DEX"}],
+            "spell_scrolls": [],
+        }
+
+
+class StoryGenerator(BaseGenerator):
+    """Generates the overarching story."""
+
+    def _generate(self, context: dict, feedback: list[str] | None = None) -> dict:
+        from src.generate.generators.llm_primitives import generate_story_primitive
+        story_seed = context.get("story_seed", "A dark force threatens the land.")
+        room_count = context.get("room_count", 1)
+        environments = context.get("environments", ["forest"])
+        result = generate_story_primitive(story_seed, room_count, environments)
+        if "error" in result:
+            raise ValueError(result["error"])
+        return result
+
+    def _fallback(self, context: dict) -> dict:
+        return {
+            "title": "The Shadow's Grasp",
+            "synopsis": "A dark cult spreads corruption through the land.",
+            "faction": {
+                "name": "The Shadow Cult",
+                "description": "A secretive order seeking to plunge the world into darkness.",
+                "leader": "The Faceless One",
+            },
+            "escalation_arc": ["Whispers of darkness", "The cult reveals itself"],
+            "climax": "Face the cult leader in a final showdown.",
+            "final_boss_name": "The Faceless One",
+            "key_npc_names": ["The Faceless One"],
+            "beats": [],
+        }

--- a/src/generate/pipeline.py
+++ b/src/generate/pipeline.py
@@ -18,8 +18,13 @@ from config import (
     NUM_ROOMS,
 )
 from src.models.maze import Maze
-from src.models.monster import generate_encounter_monsters
+from src.models.monster import generate_encounter_monsters, generate_night_monster
 from src.generate.validator import ValidationReport
+from src.generate.world_editor import (  # noqa: F401
+    create_world_bible, add_room_to_bible, get_bible_context,
+    cross_validate, write_world_bible,
+)
+
 from src.registry import registry
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
@@ -618,8 +623,14 @@ def _generate_loot_table(item_ids: list[int], difficulty: int) -> list[dict]:
 
 
 def _generate_room(room_idx: int, num_rooms: int, story, room_dir: str,
-                    all_class_options: list | None = None):
-    """Generate all content for a single room. Returns room metadata dict."""
+                    all_class_options: list | None = None,
+                    bible=None, report: ValidationReport | None = None):
+    """Generate all content for a single room. Returns room metadata dict.
+
+    When *bible* is provided, generators read it for lore context so
+    content is narratively connected to previous rooms.  *report*
+    accumulates validation findings for the manifest.
+    """
     room_level = room_idx + 1
     room_id = f"room_{room_idx}"
     id_offset = room_idx * 1000  # Offset IDs to avoid collisions across rooms
@@ -691,6 +702,15 @@ def _generate_room(room_idx: int, num_rooms: int, story, room_dir: str,
 
             npc_type = "MerchantNPC" if (is_merchant_zone and i == 0) else random.choice(NPC_TYPES)
 
+            # Assign NPC availability: ~30% day-only, ~20% night-only, ~50% always
+            avail_roll = random.random()
+            if avail_roll < 0.30:
+                npc_availability = "day"
+            elif avail_roll < 0.50:
+                npc_availability = "night"
+            else:
+                npc_availability = "always"
+
             npc_data = {
                 "id": npc_id_counter,
                 "type": npc_type,
@@ -708,6 +728,7 @@ def _generate_room(room_idx: int, num_rooms: int, story, room_dir: str,
                 "dialogue_tree": None,
                 "quest_id": None,
                 "zone": [zone_x, zone_y],
+                "availability": npc_availability,
                 "selected": False,
             }
             if npc_type == "MerchantNPC":
@@ -782,8 +803,19 @@ def _generate_room(room_idx: int, num_rooms: int, story, room_dir: str,
         if "description" not in event_data:
             event_data["description"] = "Something happens!"
 
+        # Assign time_gate to ~20% of events
+        gate_roll = random.random()
+        if gate_roll < 0.10:
+            event_data["time_gate"] = "day"
+        elif gate_roll < 0.20:
+            event_data["time_gate"] = "night"
+
         if event_type == "combat":
             monsters = generate_encounter_monsters(maze.environment, room_level)
+            # Add night-only monsters to some encounters (~30%)
+            if random.random() < 0.3:
+                night_monster = generate_night_monster(maze.environment, room_level)
+                monsters.append(night_monster)
             event_data["monsters"] = [m.to_dict() for m in monsters]
             event_data["room_level"] = room_level
             if event_data["name"].startswith("Event ") and monsters:
@@ -826,7 +858,7 @@ def _generate_room(room_idx: int, num_rooms: int, story, room_dir: str,
         event_data["profile_image"] = None
         event_list.append(event_data)
 
-    _validate_puzzle_tools(event_list, registry)
+    _validate_puzzle_tools(event_list, registry, report=report)
 
     event_position_map = []
     for idx, (ex, ey) in enumerate(event_positions):
@@ -1072,6 +1104,37 @@ def _generate_room(room_idx: int, num_rooms: int, story, room_dir: str,
     quest_path = os.path.join(room_dir, "quests.json")
     with open(quest_path, "w") as f:
         json.dump(quest_list, f, indent=2)
+
+    # --- Update Bible with this room's content ---
+    room_beat = next((b for b in story.beats if b.room_id == room_id), None)
+    beat_text = room_beat.summary if room_beat else ""
+    if bible is not None:
+        add_room_to_bible(
+            bible,
+            room_id=room_id,
+            room_level=room_level,
+            maze_environment=maze.environment,
+            story_beat=beat_text,
+            npc_pool=npc_pool,
+            event_list=event_list,
+            quest_list=quest_list,
+            item_placements=item_placements,
+            gate_encounter_id=gate_encounter_id or "",
+        )
+        # Persist Bible after each room so subsequent rooms can read it
+        write_world_bible(bible)
+        logger.info("Room %d: Bible updated (%d total entities).",
+                     room_idx, len(bible.entity_index))
+
+    # --- Update validation report ---
+    if report is not None:
+        report.rooms_validated += 1
+        if len(active_npcs) == 0:
+            report.add_critical("No active NPCs in room", phase=f"room_{room_idx}")
+        if len(event_list) == 0:
+            report.add_warning("No events in room", phase=f"room_{room_idx}")
+        if len(quest_list) == 0:
+            report.add_warning("No quests in room", phase=f"room_{room_idx}")
 
     return {
         "room_id": room_id,

--- a/src/generate/pipeline.py
+++ b/src/generate/pipeline.py
@@ -1154,8 +1154,21 @@ def _generate_room(room_idx: int, num_rooms: int, story, room_dir: str,
     }
 
 
+class GenerationAborted(Exception):
+    """Raised when generation is aborted due to critical validation failures."""
+
+
 def generate_world():
-    """Main generation pipeline. Writes all data to data/."""
+    """Main generation pipeline. Writes all data to data/.
+
+    Architecture — Bible-driven iterative generation:
+        1. Story/Bible first — generate overarching story, seed WorldBible
+        2. Entities per room — NPCs, items, monsters read Bible for lore
+        3. Events/encounters — reference existing entities from Bible
+        4. Quests/gameplay — cross-room connections via Bible
+        5. Screens/portraits last — read Bible for consistent art style
+        6. Cross-validate full Bible, abort on critical failures
+    """
     logger.info("=== MazeWorld World Generator ===")
     logger.info("Seed: %s, Mode: %s, Rooms: %d", WORLD_SEED, GAME_MODE, NUM_ROOMS)
 
@@ -1164,6 +1177,9 @@ def generate_world():
 
     registry.load()
 
+    # --- Initialise pipeline-level validation report ---
+    report = ValidationReport()
+
     num_rooms = NUM_ROOMS
     room_results = []
 
@@ -1171,7 +1187,9 @@ def generate_world():
     # (We'll re-seed before actual generation so this peek doesn't consume randomness)
     rng_state = random.getstate()
 
-    # --- Generate overarching story ---
+    # =====================================================================
+    # LAYER 1: BIBLE / STORY FIRST
+    # =====================================================================
     from src.data.world_data import ENVIRONMENT_TYPES
     story_seed = STORY_SEED or _FALLBACK_STORY_SEED
     environments = random.choices(ENVIRONMENT_TYPES, k=num_rooms)
@@ -1235,11 +1253,18 @@ def generate_world():
             key_npc_names=["The Faceless One"],
             beats=beats,
         )
+        report.add_warning("Story LLM generation failed, using fallback", phase="story")
     logger.info("Story: %s (faction: %s, %d beats)",
                 story.title, story.faction.name if story.faction else "none",
                 len(story.beats))
 
-    # --- Generate player classes (global, based on first room environment) ---
+    # --- Seed the WorldBible with the story ---
+    bible = create_world_bible(story)
+    logger.info("WorldBible created with story: %s", story.title)
+
+    # =====================================================================
+    # LAYER 2: ENTITIES — player classes (global, based on first environment)
+    # =====================================================================
     from src.generate.class_gen import generate_classes
     first_env = environments[0] if environments else "forest"
     first_env_name = _llm_generate_env_name(first_env)
@@ -1250,11 +1275,18 @@ def generate_world():
     # Restore RNG state and generate rooms
     random.setstate(rng_state)
 
-    # --- Generate each room ---
+    # =====================================================================
+    # LAYERS 2-4: PER-ROOM GENERATION (Bible-driven, sequential)
+    # Each room reads the Bible (including previous rooms), generates
+    # content, then writes back to Bible before the next room starts.
+    # =====================================================================
     for room_idx in range(num_rooms):
         room_dir = os.path.join(DATA_DIR, "rooms", f"room_{room_idx}")
         os.makedirs(room_dir, exist_ok=True)
-        result = _generate_room(room_idx, num_rooms, story, room_dir)
+        result = _generate_room(
+            room_idx, num_rooms, story, room_dir,
+            bible=bible, report=report,
+        )
         room_results.append(result)
 
     # --- Backward-compatible writes (room 0 data to legacy paths) ---
@@ -1268,7 +1300,6 @@ def generate_world():
         "event_positions": [{"x": ep["x"], "y": ep["y"], "event_id": ep["event_id"]}
                             for ep in r0["maze"].__dict__.get("_event_pos_map", [])],
     })
-    # Load event_positions from the room's maze file for legacy compat
     r0_maze_path = os.path.join(DATA_DIR, "rooms", "room_0", "maze.json")
     if os.path.exists(r0_maze_path):
         import shutil
@@ -1299,7 +1330,9 @@ def generate_world():
     with open(CLASS_PATH, "w") as f:
         json.dump(class_data_list, f, indent=2)
 
-    # --- Portraits (all rooms) ---
+    # =====================================================================
+    # LAYER 5: SCREENS / PORTRAITS LAST (read Bible for consistent style)
+    # =====================================================================
     portraits_generated = False
     player_portrait_path = None
     env_portrait_path = None
@@ -1379,10 +1412,63 @@ def generate_world():
     with open(CLASS_PATH, "w") as f:
         json.dump(class_data_list, f, indent=2)
 
-    # --- Manifest ---
-    room_manifest = []
+    # =====================================================================
+    # CROSS-VALIDATION & MANIFEST
+    # =====================================================================
+
+    # --- Cross-validate the full Bible ---
+    all_npc_pool = []
+    all_event_list = []
+    all_quest_list = []
+    all_item_placements = []
     for rr in room_results:
-        room_manifest.append({
+        all_npc_pool.extend(rr["npc_pool"])
+        all_event_list.extend(rr["event_list"])
+        all_quest_list.extend(rr["quest_list"])
+        all_item_placements.extend(rr["item_placements"])
+
+    cv_issues = cross_validate(
+        bible, all_npc_pool, all_event_list, all_quest_list, all_item_placements,
+    )
+    for issue in cv_issues:
+        report.add_warning(issue, phase="cross_validation")
+    if cv_issues:
+        logger.warning("Cross-validation found %d issues.", len(cv_issues))
+
+    # --- Final Bible write ---
+    write_world_bible(bible)
+
+    # --- Build manifest using build_manifest() ---
+    generated_at = datetime.now(timezone.utc).isoformat()
+    manifest = build_manifest(
+        seed=WORLD_SEED,
+        story_seed=story.seed,
+        game_mode=GAME_MODE,
+        num_rooms=num_rooms,
+        environments=[rr["environment"] for rr in room_results],
+        generated_at=generated_at,
+        validation=report.to_dict(),
+        active_npc_count=sum(len(rr["active_npcs"]) for rr in room_results),
+        item_count=len(all_items),
+        quest_count=sum(len(rr["quest_list"]) for rr in room_results),
+        event_list=all_event_list,
+        npc_pool=all_npc_pool,
+        player_portrait_path=player_portrait_path,
+        env_portrait_path=env_portrait_path,
+        environment=room_results[0]["environment"],
+        env_name=room_results[0]["environment_name"],
+        maze_width=MAZE_WIDTH,
+        maze_height=MAZE_HEIGHT,
+        class_count=len(class_data_list),
+        portraits_generated=portraits_generated,
+        story_title=story.title,
+        faction_name=story.faction.name if story.faction else "",
+    )
+
+    # Add per-room summary to manifest
+    manifest["rooms"] = []
+    for rr in room_results:
+        manifest["rooms"].append({
             "room_id": rr["room_id"],
             "environment": rr["environment"],
             "environment_name": rr["environment_name"],
@@ -1393,32 +1479,24 @@ def generate_world():
             "environment_portrait": rr.get("environment_portrait"),
         })
 
-    manifest = {
-        "world_seed": WORLD_SEED,
-        "num_rooms": num_rooms,
-        "environment": room_results[0]["environment"],
-        "environment_name": room_results[0]["environment_name"],
-        "maze_width": MAZE_WIDTH,
-        "maze_height": MAZE_HEIGHT,
-        "generated_at": datetime.now(timezone.utc).isoformat(),
-        "npc_pool_size": sum(len(rr["npc_pool"]) for rr in room_results),
-        "active_npc_count": sum(len(rr["active_npcs"]) for rr in room_results),
-        "quest_count": sum(len(rr["quest_list"]) for rr in room_results),
-        "event_count": sum(len(rr["event_list"]) for rr in room_results),
-        "class_count": len(class_data_list),
-        "portraits_generated": portraits_generated,
-        "player_portrait": player_portrait_path,
-        "environment_portrait": env_portrait_path,
-        "game_mode": GAME_MODE,
-        "story_title": story.title,
-        "faction_name": story.faction.name if story.faction else "",
-        "story_seed": story.seed,
-        "rooms": room_manifest,
-    }
     with open(MANIFEST_PATH, "w") as f:
         json.dump(manifest, f, indent=2)
 
+    # --- Abort on critical validation failures ---
+    if report.status == "failed":
+        logger.error(
+            "BUILD ABORTED: %d critical validation failures. See manifest for details.",
+            report.critical_failures,
+        )
+        raise GenerationAborted(
+            f"Generation aborted: {report.critical_failures} critical failures. "
+            f"Details in {MANIFEST_PATH}"
+        )
+
     logger.info("=== Generation Complete (%d rooms) ===", num_rooms)
+    logger.info("  Validation: %s (%d warnings, %d major, %d critical)",
+                report.status, report.minor_warnings,
+                report.major_retries, report.critical_failures)
     for rr in room_results:
         logger.info("  Room %d: %s (%s) — %d NPCs, %d events, %d quests",
                      rr["room_idx"], rr["environment"], rr["environment_name"],
@@ -1426,3 +1504,4 @@ def generate_world():
                      len(rr["quest_list"]))
     logger.info("  Portraits: %s", "yes" if portraits_generated else "no")
     logger.info("  Manifest: %s", MANIFEST_PATH)
+    logger.info("  WorldBible: %d entities indexed", len(bible.entity_index))

--- a/src/generate/validator.py
+++ b/src/generate/validator.py
@@ -231,3 +231,100 @@ class EventValidator(BaseValidator):
                 reasons.append("Puzzle has no solvable path with available tools")
 
         return ValidationResult(passed=len(reasons) == 0, reasons=reasons, data=data)
+
+
+class ItemValidator(BaseValidator):
+    """Validates item data for completeness and sensible values."""
+
+    VALID_CATEGORIES = {"food", "drink", "tool", "weapon", "spell_scroll"}
+
+    def validate(self, data: dict, context: dict | None = None) -> ValidationResult:
+        reasons: list[str] = []
+
+        if not data.get("name"):
+            reasons.append("Item missing name")
+
+        category = data.get("category", "")
+        if category not in self.VALID_CATEGORIES:
+            reasons.append(f"Invalid item category '{category}'")
+
+        stats = data.get("item_stats", {})
+        if not stats:
+            reasons.append("Item missing item_stats")
+            return ValidationResult(passed=False, reasons=reasons, data=data)
+
+        if category == "weapon":
+            dice = stats.get("attack_dice", "")
+            if not dice:
+                reasons.append("Weapon has no attack_dice")
+        elif category == "tool":
+            if not stats.get("attribute"):
+                reasons.append("Tool has no attribute")
+        elif category == "food":
+            if stats.get("nutrition_value", 0) <= 0:
+                reasons.append("Food has no nutrition_value")
+        elif category == "drink":
+            if stats.get("hydration_value", 0) <= 0:
+                reasons.append("Drink has no hydration_value")
+
+        price = stats.get("price", 0)
+        if price < 0:
+            reasons.append(f"Item has negative price: {price}")
+
+        return ValidationResult(passed=len(reasons) == 0, reasons=reasons, data=data)
+
+
+class NPCValidator(BaseValidator):
+    """Validates NPC data for required fields and identity."""
+
+    def validate(self, data: dict, context: dict | None = None) -> ValidationResult:
+        reasons: list[str] = []
+
+        if not data.get("name"):
+            reasons.append("NPC missing name")
+        if not data.get("type"):
+            reasons.append("NPC missing type")
+        if not data.get("environment"):
+            reasons.append("NPC missing environment")
+        if not data.get("personality"):
+            reasons.append("NPC missing personality")
+        if not data.get("opening_greeting"):
+            reasons.append("NPC missing opening_greeting")
+
+        npc_type = data.get("type", "")
+        if npc_type == "MerchantNPC":
+            if not data.get("shop_inventory"):
+                reasons.append("Merchant NPC has no shop_inventory")
+
+        return ValidationResult(passed=len(reasons) == 0, reasons=reasons, data=data)
+
+
+class MonsterValidator(BaseValidator):
+    """Validates monster data for combat-readiness."""
+
+    def validate(self, data: dict, context: dict | None = None) -> ValidationResult:
+        reasons: list[str] = []
+
+        if not data.get("name"):
+            reasons.append("Monster missing name")
+
+        hp = data.get("hp", 0)
+        if hp <= 0:
+            reasons.append(f"Monster has invalid hp: {hp}")
+
+        max_hp = data.get("max_hp", 0)
+        if max_hp <= 0:
+            reasons.append(f"Monster has invalid max_hp: {max_hp}")
+
+        if not data.get("attack_dice"):
+            reasons.append("Monster missing attack_dice")
+
+        ac = data.get("ac", 0)
+        if ac <= 0:
+            reasons.append(f"Monster has invalid ac: {ac}")
+
+        level = data.get("level", 0)
+        if level <= 0:
+            reasons.append(f"Monster has invalid level: {level}")
+
+        return ValidationResult(passed=len(reasons) == 0, reasons=reasons, data=data)

--- a/src/generate/world_editor.py
+++ b/src/generate/world_editor.py
@@ -2,6 +2,11 @@
 
 Cross-validates references between quests, NPCs, items, and encounters.
 Produces a ``WorldBible`` model that is serialised to ``data/world_bible.json``.
+
+The Bible is built **incrementally** during generation: after each room's
+content is generated, ``add_room_to_bible()`` appends that room's entities.
+Multi-room worlds accumulate lore so that later rooms can reference earlier
+content for narrative coherence.
 """
 
 import json
@@ -16,6 +21,90 @@ logger = logging.getLogger(__name__)
 WORLD_BIBLE_PATH = os.path.join("data", "world_bible.json")
 
 
+def create_world_bible(story: OverarchingStory) -> WorldBible:
+    """Create an empty WorldBible seeded with the overarching story."""
+    return WorldBible(story=story)
+
+
+def add_room_to_bible(
+    bible: WorldBible,
+    *,
+    room_id: str,
+    room_level: int,
+    maze_environment: str,
+    story_beat: str = "",
+    npc_pool: list[dict] | None = None,
+    event_list: list[dict] | None = None,
+    quest_list: list[dict] | None = None,
+    item_placements: list[dict] | None = None,
+    gate_encounter_id: str = "",
+) -> None:
+    """Append a room's entities to the WorldBible (mutates *bible* in place).
+
+    This is the incremental counterpart to ``build_world_bible()``.  It is
+    called once per room *during* generation so that subsequent rooms can
+    read the Bible for lore context.
+    """
+    npc_pool = npc_pool or []
+    event_list = event_list or []
+    quest_list = quest_list or []
+    item_placements = item_placements or []
+
+    room = RoomBible(
+        environment=maze_environment,
+        level=room_level,
+        story_beat=story_beat,
+        gate_encounter_id=gate_encounter_id,
+    )
+
+    # --- Index NPCs ---
+    active_npcs = [n for n in npc_pool if n.get("selected")]
+    for npc in active_npcs:
+        npc_id_str = str(npc["id"])
+        room.npcs.append(npc_id_str)
+        bible.entity_index[f"npc:{npc_id_str}"] = EntityRef(
+            entity_type="npc", room_id=room_id, entity_id=npc_id_str,
+        )
+
+    # --- Index items ---
+    seen_items: set[int] = set()
+    for placement in item_placements:
+        item_id = placement["item_id"]
+        if item_id not in seen_items:
+            item_id_str = str(item_id)
+            room.items.append(item_id_str)
+            bible.entity_index[f"item:{item_id_str}"] = EntityRef(
+                entity_type="item", room_id=room_id, entity_id=item_id_str,
+            )
+            seen_items.add(item_id)
+
+    # --- Index events (encounters) ---
+    for event in event_list:
+        eid = event["id"]
+        room.encounters.append(eid)
+        bible.entity_index[f"encounter:{eid}"] = EntityRef(
+            entity_type="encounter", room_id=room_id, entity_id=eid,
+        )
+        # Index monsters within combat events
+        if event.get("type") == "combat":
+            for midx, monster in enumerate(event.get("monsters", [])):
+                monster_id = f"{eid}_m{midx}"
+                room.monsters.append(monster_id)
+                bible.entity_index[f"monster:{monster_id}"] = EntityRef(
+                    entity_type="monster", room_id=room_id, entity_id=monster_id,
+                )
+
+    # --- Index quests ---
+    for quest in quest_list:
+        qid = quest["id"]
+        room.quests.append(qid)
+        bible.entity_index[f"quest:{qid}"] = EntityRef(
+            entity_type="quest", room_id=room_id, entity_id=qid,
+        )
+
+    bible.rooms[room_id] = room
+
+
 def build_world_bible(
     story: OverarchingStory,
     npc_pool: list[dict],
@@ -27,97 +116,60 @@ def build_world_bible(
 ) -> WorldBible:
     """Assemble the WorldBible cross-reference index from generated pools.
 
-    Parameters
-    ----------
-    story : OverarchingStory
-        The generated overarching story.
-    npc_pool : list[dict]
-        All generated NPCs (both selected and unselected).
-    event_list : list[dict]
-        Generated events (combat/puzzle/event).
-    quest_list : list[dict]
-        Generated quests.
-    item_placements : list[dict]
-        Items placed on the map (x, y, item_id).
-    event_position_map : list[dict]
-        Event positions (x, y, event_id).
-    maze_environment : str
-        The environment type of the maze.
-
-    Returns
-    -------
-    WorldBible
+    This is the *legacy* single-shot builder kept for backward compat.
+    New code should use ``create_world_bible()`` + ``add_room_to_bible()``.
     """
-    bible = WorldBible(story=story)
-    entity_index: dict[str, EntityRef] = {}
+    bible = create_world_bible(story)
 
-    # Single-room world uses "room_0"
-    room_id = "room_0"
-    room = RoomBible(environment=maze_environment, level=1)
-
+    beat_text = ""
     if story.beats:
-        room.story_beat = story.beats[0].summary
+        beat_text = story.beats[0].summary
 
-    # --- Index NPCs ---
-    active_npcs = [n for n in npc_pool if n.get("selected")]
-    for npc in active_npcs:
-        npc_id_str = str(npc["id"])
-        room.npcs.append(npc_id_str)
-        entity_index[f"npc:{npc_id_str}"] = EntityRef(
-            entity_type="npc",
-            room_id=room_id,
-            entity_id=npc_id_str,
-        )
-
-    # --- Index items ---
-    seen_items: set[int] = set()
-    for placement in item_placements:
-        item_id = placement["item_id"]
-        if item_id not in seen_items:
-            item_id_str = str(item_id)
-            room.items.append(item_id_str)
-            entity_index[f"item:{item_id_str}"] = EntityRef(
-                entity_type="item",
-                room_id=room_id,
-                entity_id=item_id_str,
-            )
-            seen_items.add(item_id)
-
-    # --- Index events (encounters) ---
-    for event in event_list:
-        eid = event["id"]
-        room.encounters.append(eid)
-        entity_index[f"encounter:{eid}"] = EntityRef(
-            entity_type="encounter",
-            room_id=room_id,
-            entity_id=eid,
-        )
-
-        # Index monsters within combat events
-        if event.get("type") == "combat":
-            for midx, monster in enumerate(event.get("monsters", [])):
-                monster_id = f"{eid}_m{midx}"
-                room.monsters.append(monster_id)
-                entity_index[f"monster:{monster_id}"] = EntityRef(
-                    entity_type="monster",
-                    room_id=room_id,
-                    entity_id=monster_id,
-                )
-
-    # --- Index quests ---
-    for quest in quest_list:
-        qid = quest["id"]
-        room.quests.append(qid)
-        entity_index[f"quest:{qid}"] = EntityRef(
-            entity_type="quest",
-            room_id=room_id,
-            entity_id=qid,
-        )
-
-    bible.rooms[room_id] = room
-    bible.entity_index = entity_index
-
+    add_room_to_bible(
+        bible,
+        room_id="room_0",
+        room_level=1,
+        maze_environment=maze_environment,
+        story_beat=beat_text,
+        npc_pool=npc_pool,
+        event_list=event_list,
+        quest_list=quest_list,
+        item_placements=item_placements,
+    )
     return bible
+
+
+def get_bible_context(bible: WorldBible) -> dict:
+    """Extract a serialisable lore-context dict for passing to LLM generators.
+
+    Generators read this to produce narratively connected content.
+    """
+    rooms_summary = []
+    for rid, room in bible.rooms.items():
+        rooms_summary.append({
+            "room_id": rid,
+            "environment": room.environment,
+            "level": room.level,
+            "story_beat": room.story_beat,
+            "npc_count": len(room.npcs),
+            "item_count": len(room.items),
+            "encounter_count": len(room.encounters),
+            "quest_count": len(room.quests),
+            "monster_count": len(room.monsters),
+        })
+
+    story = bible.story
+    return {
+        "story_title": story.title,
+        "story_synopsis": story.synopsis,
+        "faction_name": story.faction.name if story.faction else "",
+        "faction_description": story.faction.description if story.faction else "",
+        "climax": story.climax,
+        "final_boss": story.final_boss_name,
+        "rooms": rooms_summary,
+        "total_npcs": sum(len(r.npcs) for r in bible.rooms.values()),
+        "total_quests": sum(len(r.quests) for r in bible.rooms.values()),
+    }
 
 
 def cross_validate(bible: WorldBible, npc_pool: list[dict],
@@ -131,8 +183,9 @@ def cross_validate(bible: WorldBible, npc_pool: list[dict],
     item_ids = {p["item_id"] for p in item_placements}
 
     issues: list[str] = []
+
+    # --- Quest reference validation ---
     for quest in quest_list:
-        # Normalize NPC ID fields to strings for comparison
         normalized = dict(quest)
         for key in ("giver_npc_id", "escort_npc_id", "target_npc_id"):
             if key in normalized:
@@ -145,6 +198,34 @@ def cross_validate(bible: WorldBible, npc_pool: list[dict],
             event_ids=event_ids,
             label=f"Quest {quest['id']}",
         ))
+
+    # --- Gate encounter per non-final room ---
+    room_ids = sorted(bible.rooms.keys())
+    for rid in room_ids[:-1] if len(room_ids) > 1 else []:
+        room = bible.rooms[rid]
+        if not room.gate_encounter_id:
+            issues.append(f"{rid}: missing gate encounter for non-final room")
+
+    # --- Story quest presence per room ---
+    story_quests_by_room: dict[str, int] = {rid: 0 for rid in room_ids}
+    for quest in quest_list:
+        if quest.get("is_story_quest"):
+            qroom = quest.get("room_id", "room_0")
+            if qroom in story_quests_by_room:
+                story_quests_by_room[qroom] += 1
+    for rid, count in story_quests_by_room.items():
+        if count == 0:
+            issues.append(f"{rid}: no story quest present")
+
+    # --- NPC presence per room ---
+    for rid, room in bible.rooms.items():
+        if len(room.npcs) == 0:
+            issues.append(f"{rid}: no active NPCs")
+
+    # --- Encounter presence per room ---
+    for rid, room in bible.rooms.items():
+        if len(room.encounters) == 0:
+            issues.append(f"{rid}: no encounters")
 
     return issues
 

--- a/src/models/encounter.py
+++ b/src/models/encounter.py
@@ -25,6 +25,7 @@ class Event(BaseModel):
     profile_image: Optional[str] = None
     difficulty: int = 3
     resolved: bool = False
+    time_gate: Optional[str] = None  # "day" | "night" | None (always)
 
     class Config:
         arbitrary_types_allowed = True

--- a/src/models/monster.py
+++ b/src/models/monster.py
@@ -63,6 +63,8 @@ class Monster(BaseModel):
     profile_image: Optional[str] = None
     portrait_prompt: Optional[str] = None
 
+    time_availability: str = "always"  # "day", "night", or "always"
+
     # Battle state (not persisted)
     status_effects: Dict[str, int] = Field(default_factory=dict)
 
@@ -374,3 +376,52 @@ def create_scaled_monster(
         magic_resistance=level,
         loot_table=loot_table,
     )
+
+
+# ---------------------------------------------------------------------------
+# Night monster variants
+# ---------------------------------------------------------------------------
+
+# Night-only monster pools (shadow/dark themed)
+NIGHT_MONSTER_POOLS = {
+    "forest":  ["Shadow Wolf", "Dark Treant", "Night Spider"],
+    "cave":    ["Shadow Bat", "Dark Slime", "Night Crawler"],
+    "dungeon": ["Shadow Wraith", "Dark Skeleton", "Night Phantom"],
+    "castle":  ["Shadow Knight", "Dark Gargoyle", "Night Specter"],
+    "house":   ["Shadow Rat", "Dark Poltergeist", "Night Shade"],
+    "city":    ["Shadow Thug", "Dark Stalker", "Night Assassin"],
+}
+
+
+def generate_night_monster(environment: str, room_level: int) -> Monster:
+    """Generate a night-only monster with dark elemental affinity and harder stats."""
+    pool = NIGHT_MONSTER_POOLS.get(environment, NIGHT_MONSTER_POOLS["city"])
+    monster = generate_monster(environment, room_level, name_override=random.choice(pool))
+    monster.elemental_affinity = "dark"
+    monster.damage_type = "dark"
+    monster.time_availability = "night"
+    monster.hp = int(monster.hp * 1.25)
+    monster.max_hp = monster.hp
+    monster.str_mod += 1
+    return monster
+
+
+def generate_night_variant(monster: Monster) -> Monster:
+    """Return a harder night variant of an existing monster.
+
+    +25% HP, +1 str_mod, dark elemental affinity, 'Nightstalker' name prefix.
+    """
+    data = monster.model_dump()
+    data.pop("status_effects", None)
+    data["id"] = str(_uuid.uuid4())
+    data["hp"] = int(monster.hp * 1.25)
+    data["max_hp"] = data["hp"]
+    data["str_mod"] = monster.str_mod + 1
+    data["elemental_affinity"] = "dark"
+    data["damage_type"] = "dark"
+    data["time_availability"] = "night"
+    name = monster.name or monster.species
+    if not name.startswith("Nightstalker"):
+        data["name"] = f"Nightstalker {name}"
+        data["species"] = f"Nightstalker {monster.species}"
+    return Monster(**data)

--- a/src/models/npc.py
+++ b/src/models/npc.py
@@ -25,6 +25,7 @@ class NPC(BaseModel):
     dialogue_tree: Optional[dict] = None
     quest_id: Optional[str] = None
     zone: Optional[List[int]] = None
+    availability: Optional[str] = None  # "day" | "night" | "always" | None
     selected: bool = True
     interaction_history: List[dict] = Field(default_factory=list)
     has_met_player: bool = False

--- a/src/models/time.py
+++ b/src/models/time.py
@@ -1,4 +1,4 @@
-"""Day/Night cycle data model."""
+"""Day/Night cycle data model — real-time based."""
 
 from pydantic import BaseModel
 from enum import Enum
@@ -19,23 +19,29 @@ PERIOD_SEQUENCE = [
     (TimePeriod.NIGHT, 0.35),
 ]
 
+# Default full cycle: ~16 real minutes (4 min per phase)
+DEFAULT_CYCLE_MS = 960_000
+
 
 class DayNightCycle(BaseModel):
-    """Action-based day/night cycle.
+    """Real-time day/night cycle.
 
-    Time advances with movement steps, combat turns, and rest actions.
-    A full cycle = ``cycle_length`` actions (default 200).
+    Time advances with wall-clock time via ``update(current_time_ms)``.
+    Each phase (dawn/day/dusk/night) lasts ~4 real minutes by default.
+    Full cycle = ``cycle_duration_ms`` (default ~16 minutes).
+    Rest can still jump the timer forward via ``advance_hours``.
     """
-    ticks: int = 0
-    cycle_length: int = 200
+    elapsed_ms: int = 0
+    cycle_duration_ms: int = DEFAULT_CYCLE_MS
+    last_update_ms: int = 0
 
     @property
     def current_period(self) -> TimePeriod:
-        """Derive the current period from ticks."""
-        position = self.ticks % self.cycle_length
+        """Derive the current period from elapsed real time."""
+        position = self.elapsed_ms % self.cycle_duration_ms
         cumulative = 0.0
         for period, fraction in PERIOD_SEQUENCE:
-            cumulative += fraction * self.cycle_length
+            cumulative += fraction * self.cycle_duration_ms
             if position < cumulative:
                 return period
         return TimePeriod.NIGHT  # fallback
@@ -43,13 +49,13 @@ class DayNightCycle(BaseModel):
     @property
     def period_progress(self) -> float:
         """Progress within the current period (0.0 to 1.0)."""
-        position = self.ticks % self.cycle_length
+        position = self.elapsed_ms % self.cycle_duration_ms
         cumulative = 0.0
         for period, fraction in PERIOD_SEQUENCE:
-            period_ticks = fraction * self.cycle_length
-            if position < cumulative + period_ticks:
-                return (position - cumulative) / period_ticks
-            cumulative += period_ticks
+            period_ms = fraction * self.cycle_duration_ms
+            if position < cumulative + period_ms:
+                return (position - cumulative) / period_ms
+            cumulative += period_ms
         return 1.0
 
     @property
@@ -59,24 +65,52 @@ class DayNightCycle(BaseModel):
     @property
     def day_number(self) -> int:
         """Which day it is (starting from 1)."""
-        return self.ticks // self.cycle_length + 1
+        return self.elapsed_ms // self.cycle_duration_ms + 1
+
+    def update(self, current_time_ms: int) -> None:
+        """Advance elapsed time by the real-time delta since last update.
+
+        Call this once per frame with ``pygame.time.get_ticks()``.
+        """
+        if self.last_update_ms == 0:
+            self.last_update_ms = current_time_ms
+            return
+        delta = current_time_ms - self.last_update_ms
+        if delta > 0:
+            self.elapsed_ms += delta
+        self.last_update_ms = current_time_ms
 
     def advance(self, steps: int = 1) -> None:
-        """Advance time by the given number of action steps."""
-        self.ticks += steps
+        """Advance time by action steps (for combat turns / legacy callers).
+
+        Each step = 1/200th of a full cycle.
+        """
+        ms_per_step = self.cycle_duration_ms // 200
+        self.elapsed_ms += ms_per_step * steps
 
     def advance_hours(self, hours: int) -> None:
-        """Advance time by a number of in-game hours.
+        """Jump timer forward by in-game hours (for rest mechanic).
 
-        A full cycle = 24 hours, so 1 hour = cycle_length / 24 ticks.
+        A full cycle = 24 hours, so 1 hour = cycle_duration_ms / 24 ms.
         """
-        ticks_per_hour = self.cycle_length / 24
-        self.advance(int(ticks_per_hour * hours))
+        ms_per_hour = self.cycle_duration_ms / 24
+        self.elapsed_ms += int(ms_per_hour * hours)
 
     def serialize(self) -> dict:
-        return {"ticks": self.ticks, "cycle_length": self.cycle_length}
+        return {
+            "elapsed_ms": self.elapsed_ms,
+            "cycle_duration_ms": self.cycle_duration_ms,
+        }
 
     @classmethod
     def deserialize(cls, data: dict) -> "DayNightCycle":
-        return cls(ticks=data.get("ticks", 0),
-                   cycle_length=data.get("cycle_length", 200))
+        if "elapsed_ms" in data:
+            return cls(
+                elapsed_ms=data["elapsed_ms"],
+                cycle_duration_ms=data.get("cycle_duration_ms", DEFAULT_CYCLE_MS),
+            )
+        # Legacy: convert action-based ticks to elapsed_ms
+        ticks = data.get("ticks", 0)
+        cycle_length = data.get("cycle_length", 200)
+        elapsed_ms = int(ticks * DEFAULT_CYCLE_MS / cycle_length)
+        return cls(elapsed_ms=elapsed_ms, cycle_duration_ms=DEFAULT_CYCLE_MS)

--- a/src/prompts/checker_prompts/__init__.py
+++ b/src/prompts/checker_prompts/__init__.py
@@ -1,0 +1,85 @@
+"""Checker prompts for LLM-based content review.
+
+These prompts support the Checker stage of the Gen -> Check -> Validate chain.
+Checkers perform structural and thematic review of generated content.
+"""
+
+from src.prompts.base import LLMRequest
+
+
+def event_check_prompt(event_data: dict, env_type: str, env_name: str) -> LLMRequest:
+    """Prompt to review a generated event for theme and structural issues."""
+    return LLMRequest(
+        system=(
+            "You are a game content reviewer for a fantasy RPG called MazeWorld. "
+            "Review the following event data for structural issues and thematic fit. "
+            "The event should match the environment theme. "
+            "Respond with a JSON object: {\"passed\": true/false, \"issues\": [\"...\"]}"
+        ),
+        user_message=(
+            f"Environment: {env_type} ({env_name})\n"
+            f"Event: {event_data}\n\n"
+            "Check: Does this event have a name, description, and type? "
+            "Does it fit the environment theme? "
+            "If combat, does it have monsters? If puzzle, does it have a walk-away option?"
+        ),
+        max_tokens=300,
+    )
+
+
+def quest_check_prompt(quest_data: dict, available_npcs: list, available_items: list) -> LLMRequest:
+    """Prompt to review a generated quest for completability."""
+    return LLMRequest(
+        system=(
+            "You are a game content reviewer for a fantasy RPG called MazeWorld. "
+            "Review the following quest for completability given the available NPCs and items. "
+            "Respond with a JSON object: {\"passed\": true/false, \"issues\": [\"...\"]}"
+        ),
+        user_message=(
+            f"Quest: {quest_data}\n"
+            f"Available NPCs: {[n.get('name', n.get('id')) for n in available_npcs]}\n"
+            f"Available Items: {[i.get('name', i.get('id')) for i in available_items]}\n\n"
+            "Check: Can this quest be completed with the available entities? "
+            "Are all referenced NPCs and items present?"
+        ),
+        max_tokens=300,
+    )
+
+
+def npc_check_prompt(npc_data: dict, env_type: str, env_name: str) -> LLMRequest:
+    """Prompt to review an NPC for thematic fit and personality coherence."""
+    return LLMRequest(
+        system=(
+            "You are a game content reviewer for a fantasy RPG called MazeWorld. "
+            "Review the following NPC for thematic fit with the environment. "
+            "Respond with a JSON object: {\"passed\": true/false, \"issues\": [\"...\"]}"
+        ),
+        user_message=(
+            f"Environment: {env_type} ({env_name})\n"
+            f"NPC name: {npc_data.get('name')}\n"
+            f"Job: {npc_data.get('job')}\n"
+            f"Personality: {npc_data.get('personality')}\n"
+            f"Greeting: {npc_data.get('opening_greeting', '')}\n\n"
+            "Check: Does this NPC fit the environment? Is the personality coherent? "
+            "Does the greeting make sense for the character?"
+        ),
+        max_tokens=300,
+    )
+
+
+def item_check_prompt(items_data: dict, env_type: str, env_name: str) -> LLMRequest:
+    """Prompt to review generated items for thematic fit."""
+    return LLMRequest(
+        system=(
+            "You are a game content reviewer for a fantasy RPG called MazeWorld. "
+            "Review the following items for thematic fit with the environment. "
+            "Respond with a JSON object: {\"passed\": true/false, \"issues\": [\"...\"]}"
+        ),
+        user_message=(
+            f"Environment: {env_type} ({env_name})\n"
+            f"Items: {items_data}\n\n"
+            "Check: Do these items fit the environment theme? "
+            "Does each item have a name and appropriate stats for its category?"
+        ),
+        max_tokens=300,
+    )

--- a/src/prompts/validator_prompts/__init__.py
+++ b/src/prompts/validator_prompts/__init__.py
@@ -1,0 +1,84 @@
+"""Validator prompts for LLM-based content validation.
+
+These prompts support the Validator stage of the Gen -> Check -> Validate chain.
+Validators perform deep logic and balance validation beyond structural checks.
+"""
+
+from src.prompts.base import LLMRequest
+
+
+def event_validate_prompt(event_data: dict, tool_attributes: set, env_type: str) -> LLMRequest:
+    """Prompt to validate event solvability and balance."""
+    return LLMRequest(
+        system=(
+            "You are a game balance validator for a fantasy RPG called MazeWorld. "
+            "Validate the following event for solvability and difficulty balance. "
+            "Respond with a JSON object: {\"passed\": true/false, \"reasons\": [\"...\"]}"
+        ),
+        user_message=(
+            f"Event: {event_data}\n"
+            f"Available tool attributes: {list(tool_attributes)}\n"
+            f"Environment: {env_type}\n\n"
+            "Validate: Is this event solvable? If it's a puzzle, can the player solve it "
+            "with available tools? Is the difficulty appropriate for the environment level?"
+        ),
+        max_tokens=300,
+    )
+
+
+def quest_validate_prompt(
+    quest_data: dict, npc_ids: set, item_ids: set, event_ids: set,
+) -> LLMRequest:
+    """Prompt to validate quest completability in the world state."""
+    return LLMRequest(
+        system=(
+            "You are a game balance validator for a fantasy RPG called MazeWorld. "
+            "Validate quest completability given the current world state. "
+            "Respond with a JSON object: {\"passed\": true/false, \"reasons\": [\"...\"]}"
+        ),
+        user_message=(
+            f"Quest: {quest_data}\n"
+            f"Available NPC IDs: {list(npc_ids)[:20]}\n"
+            f"Available Item IDs: {list(item_ids)[:20]}\n"
+            f"Available Event IDs: {list(event_ids)[:20]}\n\n"
+            "Validate: Can this quest be completed? Are all referenced entities available? "
+            "Is the quest chain depth reasonable (max 2 prerequisites)?"
+        ),
+        max_tokens=300,
+    )
+
+
+def class_validate_prompt(class_data: dict) -> LLMRequest:
+    """Prompt to validate a player class for balance and completeness."""
+    return LLMRequest(
+        system=(
+            "You are a game balance validator for a fantasy RPG called MazeWorld. "
+            "Validate the following player class for stat balance, ability coverage, "
+            "and thematic coherence. Total stat budget must equal 72. "
+            "Respond with a JSON object: {\"passed\": true/false, \"reasons\": [\"...\"]}"
+        ),
+        user_message=(
+            f"Class: {class_data}\n\n"
+            "Validate: Does the stat total equal 72? Are primary stats 14-18, "
+            "secondary 11-14, dump 6-10? Does the class have enough abilities/spells?"
+        ),
+        max_tokens=300,
+    )
+
+
+def monster_validate_prompt(monster_data: dict, room_level: int) -> LLMRequest:
+    """Prompt to validate monster combat readiness and level appropriateness."""
+    return LLMRequest(
+        system=(
+            "You are a game balance validator for a fantasy RPG called MazeWorld. "
+            "Validate this monster for combat readiness and level-appropriate stats. "
+            "Respond with a JSON object: {\"passed\": true/false, \"reasons\": [\"...\"]}"
+        ),
+        user_message=(
+            f"Monster: {monster_data}\n"
+            f"Room level: {room_level}\n\n"
+            "Validate: Does the monster have valid HP, AC, and attack dice? "
+            "Are the stats appropriate for the room level?"
+        ),
+        max_tokens=300,
+    )

--- a/src/prompts/world_editor_prompts/__init__.py
+++ b/src/prompts/world_editor_prompts/__init__.py
@@ -1,0 +1,78 @@
+"""World Editor prompts for LLM-based cross-content validation and Bible building.
+
+These prompts support the World Editor role which builds and maintains the
+WorldBible — the cross-content reference index ensuring narrative coherence.
+"""
+
+from src.prompts.base import LLMRequest
+
+
+def cross_validate_prompt(bible_context: dict, quest_list: list, npc_names: list) -> LLMRequest:
+    """Prompt to cross-validate world content for narrative coherence."""
+    return LLMRequest(
+        system=(
+            "You are the World Editor for a fantasy RPG called MazeWorld. "
+            "Your job is to cross-validate all generated content for narrative coherence. "
+            "Check that quests reference valid NPCs, items, and events. "
+            "Check that the story arc is consistent across rooms. "
+            "Respond with a JSON object: {\"issues\": [\"...\"], \"suggestions\": [\"...\"]}"
+        ),
+        user_message=(
+            f"World context: {bible_context}\n"
+            f"Quests: {quest_list[:10]}\n"
+            f"NPC names: {npc_names[:20]}\n\n"
+            "Cross-validate: Are quest references valid? Does the story flow between rooms? "
+            "Are there any narrative inconsistencies or orphaned references?"
+        ),
+        max_tokens=500,
+    )
+
+
+def bible_lore_prompt(
+    story_title: str, story_synopsis: str, faction_name: str,
+    room_environment: str, room_level: int, story_beat: str,
+) -> LLMRequest:
+    """Prompt to generate lore context for the World Bible.
+
+    Used to provide narrative guidance to content generators so they produce
+    thematically coherent content connected to the overarching story.
+    """
+    return LLMRequest(
+        system=(
+            "You are the World Editor for MazeWorld. Generate a brief lore context "
+            "that content generators should reference when creating NPCs, items, events, "
+            "and quests for this room. Include faction presence, environmental flavor, "
+            "and narrative hooks that connect to the overarching story. "
+            "Respond with a JSON object: {\"lore_context\": \"...\", \"themes\": [\"...\"], "
+            "\"naming_hints\": [\"...\"]}"
+        ),
+        user_message=(
+            f"Story: {story_title} — {story_synopsis}\n"
+            f"Faction: {faction_name}\n"
+            f"Room environment: {room_environment} (level {room_level})\n"
+            f"Story beat: {story_beat}\n\n"
+            "Generate lore context for this room's content generators."
+        ),
+        max_tokens=400,
+    )
+
+
+def story_consistency_prompt(
+    story: dict, rooms_generated: list[dict],
+) -> LLMRequest:
+    """Prompt to check story consistency across all generated rooms."""
+    return LLMRequest(
+        system=(
+            "You are the World Editor for MazeWorld. Review the story arc and all "
+            "generated rooms for consistency. Check that escalation progresses, "
+            "faction presence makes sense, and the narrative builds toward the climax. "
+            "Respond with a JSON object: {\"consistent\": true/false, \"issues\": [\"...\"]}"
+        ),
+        user_message=(
+            f"Story: {story}\n"
+            f"Rooms generated: {rooms_generated}\n\n"
+            "Check story consistency: Does escalation progress? "
+            "Is faction presence coherent? Does the narrative build properly?"
+        ),
+        max_tokens=400,
+    )

--- a/tests/test_bible_pipeline.py
+++ b/tests/test_bible_pipeline.py
@@ -1,0 +1,560 @@
+"""Tests for Phase 2/10: Bible-driven pipeline, incremental Bible building,
+new checkers/validators, generator base class, and manifest validation.
+"""
+
+import json
+
+from src.models.story import OverarchingStory, Faction
+
+from src.generate.world_editor import (
+    create_world_bible, add_room_to_bible, get_bible_context,
+    cross_validate, write_world_bible,
+)
+from src.generate.checker import (
+    ItemChecker, NPCChecker, MonsterChecker,
+)
+from src.generate.validator import (
+    ValidationReport, ItemValidator, NPCValidator, MonsterValidator,
+)
+from src.generate.generator import (
+    BaseGenerator,
+)
+from src.generate.pipeline import build_manifest, GenerationAborted
+
+
+# ---------------------------------------------------------------------------
+# Incremental Bible building
+# ---------------------------------------------------------------------------
+
+class TestCreateWorldBible:
+    def test_creates_empty_bible_with_story(self):
+        story = OverarchingStory(title="Test", synopsis="A test story")
+        bible = create_world_bible(story)
+        assert bible.story.title == "Test"
+        assert len(bible.rooms) == 0
+        assert len(bible.entity_index) == 0
+
+
+class TestAddRoomToBible:
+    def test_adds_single_room(self):
+        story = OverarchingStory(title="T")
+        bible = create_world_bible(story)
+        add_room_to_bible(
+            bible,
+            room_id="room_0",
+            room_level=1,
+            maze_environment="forest",
+            story_beat="Darkness gathers",
+            npc_pool=[
+                {"id": 100, "name": "Alice", "selected": True},
+                {"id": 101, "name": "Bob", "selected": False},
+            ],
+            event_list=[
+                {"id": "evt_000", "type": "combat", "monsters": [{"name": "Rat"}]},
+            ],
+            quest_list=[
+                {"id": "q_000", "type": "fetch"},
+            ],
+            item_placements=[
+                {"item_id": 200, "x": 1, "y": 1},
+            ],
+            gate_encounter_id="gate_0",
+        )
+        assert "room_0" in bible.rooms
+        room = bible.rooms["room_0"]
+        assert room.environment == "forest"
+        assert room.story_beat == "Darkness gathers"
+        assert room.gate_encounter_id == "gate_0"
+        assert len(room.npcs) == 1  # Only selected NPCs
+        assert "npc:100" in bible.entity_index
+        assert "npc:101" not in bible.entity_index
+        assert len(room.encounters) == 1
+        assert len(room.monsters) == 1
+        assert len(room.quests) == 1
+        assert len(room.items) == 1
+
+    def test_multi_room_incremental(self):
+        story = OverarchingStory(title="Multi")
+        bible = create_world_bible(story)
+
+        # Room 0
+        add_room_to_bible(
+            bible, room_id="room_0", room_level=1, maze_environment="forest",
+            npc_pool=[{"id": 100, "selected": True}],
+            event_list=[{"id": "r0_evt_0", "type": "puzzle"}],
+        )
+        assert len(bible.rooms) == 1
+        assert len(bible.entity_index) == 2  # npc + encounter
+
+        # Room 1 — Bible now has room 0 content
+        add_room_to_bible(
+            bible, room_id="room_1", room_level=2, maze_environment="cave",
+            npc_pool=[{"id": 200, "selected": True}],
+            event_list=[{"id": "r1_evt_0", "type": "combat", "monsters": [{"name": "Bat"}]}],
+        )
+        assert len(bible.rooms) == 2
+        assert "npc:100" in bible.entity_index  # Room 0 still present
+        assert "npc:200" in bible.entity_index  # Room 1 added
+        assert len(bible.entity_index) == 5  # 2 npcs + 2 encounters + 1 monster
+
+
+class TestGetBibleContext:
+    def test_context_includes_story_and_rooms(self):
+        story = OverarchingStory(
+            title="Test Story", synopsis="Synopsis",
+            faction=Faction(name="Evil", description="Bad"),
+        )
+        bible = create_world_bible(story)
+        add_room_to_bible(
+            bible, room_id="room_0", room_level=1, maze_environment="forest",
+            npc_pool=[{"id": 100, "selected": True}],
+        )
+        ctx = get_bible_context(bible)
+        assert ctx["story_title"] == "Test Story"
+        assert ctx["faction_name"] == "Evil"
+        assert len(ctx["rooms"]) == 1
+        assert ctx["rooms"][0]["environment"] == "forest"
+        assert ctx["total_npcs"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Extended cross-validation
+# ---------------------------------------------------------------------------
+
+class TestCrossValidateExtended:
+    def _make_bible_2rooms(self):
+        story = OverarchingStory(title="T")
+        bible = create_world_bible(story)
+        add_room_to_bible(
+            bible, room_id="room_0", room_level=1, maze_environment="forest",
+            npc_pool=[{"id": 100, "selected": True}],
+            gate_encounter_id="gate_0",
+        )
+        add_room_to_bible(
+            bible, room_id="room_1", room_level=2, maze_environment="cave",
+            npc_pool=[{"id": 200, "selected": True}],
+        )
+        return bible
+
+    def test_missing_gate_encounter(self):
+        story = OverarchingStory(title="T")
+        bible = create_world_bible(story)
+        add_room_to_bible(
+            bible, room_id="room_0", room_level=1, maze_environment="forest",
+            gate_encounter_id="",  # Missing gate for non-final room
+        )
+        add_room_to_bible(
+            bible, room_id="room_1", room_level=2, maze_environment="cave",
+        )
+        issues = cross_validate(bible, [], [], [], [])
+        assert any("gate encounter" in i for i in issues)
+
+    def test_gate_on_final_room_not_required(self):
+        story = OverarchingStory(title="T")
+        bible = create_world_bible(story)
+        add_room_to_bible(
+            bible, room_id="room_0", room_level=1, maze_environment="forest",
+            gate_encounter_id="gate_0",
+        )
+        add_room_to_bible(
+            bible, room_id="room_1", room_level=2, maze_environment="cave",
+            gate_encounter_id="",  # Final room, no gate needed
+        )
+        issues = cross_validate(bible, [], [], [], [])
+        gate_issues = [i for i in issues if "gate encounter" in i]
+        assert len(gate_issues) == 0
+
+    def test_missing_story_quest(self):
+        bible = self._make_bible_2rooms()
+        quest_list = [
+            {"id": "q_0", "type": "fetch", "giver_npc_id": 100,
+             "room_id": "room_0", "is_story_quest": False},
+        ]
+        npc_pool = [{"id": 100, "selected": True}]
+        issues = cross_validate(bible, npc_pool, [], quest_list, [])
+        # Both rooms should flag missing story quest
+        story_issues = [i for i in issues if "story quest" in i]
+        assert len(story_issues) >= 1
+
+    def test_empty_room_npcs(self):
+        story = OverarchingStory(title="T")
+        bible = create_world_bible(story)
+        add_room_to_bible(
+            bible, room_id="room_0", room_level=1, maze_environment="forest",
+            npc_pool=[],  # No NPCs at all
+        )
+        issues = cross_validate(bible, [], [], [], [])
+        assert any("no active NPCs" in i for i in issues)
+
+
+# ---------------------------------------------------------------------------
+# New Checkers
+# ---------------------------------------------------------------------------
+
+class TestItemChecker:
+    def test_valid_food_passes(self):
+        checker = ItemChecker()
+        item = {"name": "Bread", "category": "food",
+                "item_stats": {"nutrition_value": 15, "price": 5}}
+        result = checker.check(item)
+        assert result.passed
+
+    def test_missing_name_fails(self):
+        checker = ItemChecker()
+        item = {"category": "food", "item_stats": {"nutrition_value": 15}}
+        result = checker.check(item)
+        assert not result.passed
+        assert any("missing name" in i for i in result.issues)
+
+    def test_invalid_category_fails(self):
+        checker = ItemChecker()
+        item = {"name": "Thing", "category": "invalid", "item_stats": {}}
+        result = checker.check(item)
+        assert not result.passed
+
+    def test_weapon_missing_dice_fails(self):
+        checker = ItemChecker()
+        item = {"name": "Sword", "category": "weapon",
+                "item_stats": {"stat_modifier": "STR"}}
+        result = checker.check(item)
+        assert not result.passed
+        assert any("attack_dice" in i for i in result.issues)
+
+    def test_tool_missing_attribute_fails(self):
+        checker = ItemChecker()
+        item = {"name": "Hammer", "category": "tool", "item_stats": {}}
+        result = checker.check(item)
+        assert not result.passed
+
+    def test_food_no_nutrition_fails(self):
+        checker = ItemChecker()
+        item = {"name": "Empty", "category": "food",
+                "item_stats": {"nutrition_value": 0, "hydration_value": 0}}
+        result = checker.check(item)
+        assert not result.passed
+
+
+class TestNPCChecker:
+    def test_valid_npc_passes(self):
+        checker = NPCChecker()
+        npc = {"name": "Alice", "type": "StaticNPC",
+               "environment": "forest", "personality": "kind"}
+        result = checker.check(npc)
+        assert result.passed
+
+    def test_missing_fields_fails(self):
+        checker = NPCChecker()
+        npc = {"name": "Alice"}
+        result = checker.check(npc)
+        assert not result.passed
+
+    def test_invalid_type_fails(self):
+        checker = NPCChecker()
+        npc = {"name": "Alice", "type": "InvalidNPC",
+               "environment": "forest", "personality": "kind"}
+        result = checker.check(npc)
+        assert not result.passed
+
+    def test_empty_name_fails(self):
+        checker = NPCChecker()
+        npc = {"name": "", "type": "StaticNPC",
+               "environment": "forest", "personality": "kind"}
+        result = checker.check(npc)
+        assert not result.passed
+
+
+class TestMonsterChecker:
+    def test_valid_monster_passes(self):
+        checker = MonsterChecker()
+        monster = {"name": "Goblin", "hp": 20, "attack_dice": "1d6", "ac": 12}
+        result = checker.check(monster)
+        assert result.passed
+
+    def test_missing_name_fails(self):
+        checker = MonsterChecker()
+        monster = {"hp": 20, "attack_dice": "1d6", "ac": 12}
+        result = checker.check(monster)
+        assert not result.passed
+
+    def test_zero_hp_fails(self):
+        checker = MonsterChecker()
+        monster = {"name": "Ghost", "hp": 0, "attack_dice": "1d4", "ac": 10}
+        result = checker.check(monster)
+        assert not result.passed
+
+    def test_missing_attack_dice_fails(self):
+        checker = MonsterChecker()
+        monster = {"name": "Slime", "hp": 10, "ac": 8}
+        result = checker.check(monster)
+        assert not result.passed
+
+
+# ---------------------------------------------------------------------------
+# New Validators
+# ---------------------------------------------------------------------------
+
+class TestItemValidator:
+    def test_valid_weapon(self):
+        v = ItemValidator()
+        item = {"name": "Sword", "category": "weapon",
+                "item_stats": {"attack_dice": "1d6", "stat_modifier": "STR", "price": 20}}
+        result = v.validate(item)
+        assert result.passed
+
+    def test_food_no_nutrition(self):
+        v = ItemValidator()
+        item = {"name": "Empty", "category": "food",
+                "item_stats": {"nutrition_value": 0, "price": 5}}
+        result = v.validate(item)
+        assert not result.passed
+
+    def test_negative_price(self):
+        v = ItemValidator()
+        item = {"name": "Bread", "category": "food",
+                "item_stats": {"nutrition_value": 15, "price": -5}}
+        result = v.validate(item)
+        assert not result.passed
+
+    def test_missing_stats(self):
+        v = ItemValidator()
+        item = {"name": "Thing", "category": "food"}
+        result = v.validate(item)
+        assert not result.passed
+
+
+class TestNPCValidator:
+    def test_valid_npc(self):
+        v = NPCValidator()
+        npc = {"name": "Alice", "type": "StaticNPC", "environment": "forest",
+               "personality": "kind", "opening_greeting": "Hello!"}
+        result = v.validate(npc)
+        assert result.passed
+
+    def test_missing_greeting(self):
+        v = NPCValidator()
+        npc = {"name": "Bob", "type": "RandomNPC", "environment": "cave",
+               "personality": "grumpy"}
+        result = v.validate(npc)
+        assert not result.passed
+
+    def test_merchant_no_shop(self):
+        v = NPCValidator()
+        npc = {"name": "Trader", "type": "MerchantNPC", "environment": "city",
+               "personality": "shrewd", "opening_greeting": "Buy something!"}
+        result = v.validate(npc)
+        assert not result.passed
+        assert any("shop_inventory" in r for r in result.reasons)
+
+
+class TestMonsterValidator:
+    def test_valid_monster(self):
+        v = MonsterValidator()
+        monster = {"name": "Rat", "hp": 10, "max_hp": 10,
+                   "attack_dice": "1d4", "ac": 8, "level": 1}
+        result = v.validate(monster)
+        assert result.passed
+
+    def test_zero_max_hp(self):
+        v = MonsterValidator()
+        monster = {"name": "Ghost", "hp": 10, "max_hp": 0,
+                   "attack_dice": "1d4", "ac": 10, "level": 1}
+        result = v.validate(monster)
+        assert not result.passed
+
+    def test_missing_level(self):
+        v = MonsterValidator()
+        monster = {"name": "Slime", "hp": 5, "max_hp": 5,
+                   "attack_dice": "1d4", "ac": 6}
+        result = v.validate(monster)
+        assert not result.passed
+
+
+# ---------------------------------------------------------------------------
+# ValidationReport wiring
+# ---------------------------------------------------------------------------
+
+class TestValidationReportInManifest:
+    def test_build_manifest_includes_validation(self):
+        report = ValidationReport()
+        report.rooms_validated = 2
+        report.add_warning("test warning", phase="test")
+
+        manifest = build_manifest(
+            seed=42, story_seed="test", game_mode="offline_static",
+            num_rooms=2, environments=["forest", "cave"],
+            generated_at="2026-01-01T00:00:00Z",
+            validation=report.to_dict(),
+            active_npc_count=4, item_count=10, quest_count=3,
+            event_list=[], npc_pool=[],
+            player_portrait_path=None, env_portrait_path=None,
+            environment="forest", env_name="Whisperwood",
+            maze_width=40, maze_height=25,
+            class_count=4, portraits_generated=False,
+            story_title="Test", faction_name="Evil",
+        )
+        assert "validation" in manifest
+        assert manifest["validation"]["status"] == "passed_with_warnings"
+        assert manifest["validation"]["rooms_validated"] == 2
+        assert manifest["validation"]["minor_warnings"] == 1
+
+    def test_validation_report_status_lifecycle(self):
+        report = ValidationReport()
+        assert report.status == "passed"
+
+        report.add_warning("minor issue")
+        assert report.status == "passed_with_warnings"
+
+        report.add_critical("critical issue")
+        assert report.status == "failed"
+
+
+# ---------------------------------------------------------------------------
+# Generator base class
+# ---------------------------------------------------------------------------
+
+class TestBaseGenerator:
+    def test_simple_generator_passes(self):
+        class SimpleGen(BaseGenerator):
+            def _generate(self, context, feedback=None):
+                return {"value": 42}
+            def _fallback(self, context):
+                return {"value": 0}
+
+        gen = SimpleGen()
+        result = gen.generate({}, label="test")
+        assert result.passed
+        assert result.content == {"value": 42}
+        assert not result.used_fallback
+        assert result.attempts == 1
+
+    def test_generator_uses_fallback_on_exception(self):
+        class FailGen(BaseGenerator):
+            max_retries = 2
+            def _generate(self, context, feedback=None):
+                raise RuntimeError("LLM down")
+            def _fallback(self, context):
+                return {"fallback": True}
+
+        gen = FailGen()
+        report = ValidationReport()
+        result = gen.generate({}, report=report, label="test")
+        assert result.passed
+        assert result.used_fallback
+        assert result.content == {"fallback": True}
+        assert report.major_retries >= 1
+
+    def test_generator_retries_on_check_failure(self):
+        from src.generate.checker import BaseChecker, CheckResult
+
+        class StrictChecker(BaseChecker):
+            def check(self, data, context=None):
+                if data.get("attempt", 0) < 2:
+                    return CheckResult(passed=False, issues=["not ready"])
+                return CheckResult(passed=True, data=data)
+
+        call_count = [0]
+        class RetryGen(BaseGenerator):
+            max_retries = 3
+            def __init__(self):
+                self.checker = StrictChecker()
+            def _generate(self, context, feedback=None):
+                call_count[0] += 1
+                return {"attempt": call_count[0]}
+            def _fallback(self, context):
+                return {"fallback": True}
+
+        gen = RetryGen()
+        result = gen.generate({}, label="test")
+        assert result.passed
+        assert not result.used_fallback
+        assert result.content["attempt"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Prompt directory imports
+# ---------------------------------------------------------------------------
+
+class TestPromptImports:
+    def test_checker_prompts_importable(self):
+        from src.prompts.checker_prompts import (
+            event_check_prompt, quest_check_prompt,
+            npc_check_prompt, item_check_prompt,
+        )
+        assert callable(event_check_prompt)
+        assert callable(quest_check_prompt)
+        assert callable(npc_check_prompt)
+        assert callable(item_check_prompt)
+
+    def test_validator_prompts_importable(self):
+        from src.prompts.validator_prompts import (
+            event_validate_prompt,
+        )
+        assert callable(event_validate_prompt)
+
+    def test_world_editor_prompts_importable(self):
+        from src.prompts.world_editor_prompts import (
+            cross_validate_prompt, bible_lore_prompt,
+        )
+        assert callable(cross_validate_prompt)
+        assert callable(bible_lore_prompt)
+
+    def test_checker_prompt_returns_llm_request(self):
+        from src.prompts.checker_prompts import event_check_prompt
+        from src.prompts.base import LLMRequest
+        result = event_check_prompt(
+            {"name": "Fight", "type": "combat"},
+            "forest", "Whisperwood",
+        )
+        assert isinstance(result, LLMRequest)
+        assert result.max_tokens > 0
+
+
+# ---------------------------------------------------------------------------
+# GenerationAborted exception
+# ---------------------------------------------------------------------------
+
+class TestGenerationAborted:
+    def test_exception_exists(self):
+        assert issubclass(GenerationAborted, Exception)
+
+    def test_exception_message(self):
+        exc = GenerationAborted("test failure")
+        assert "test failure" in str(exc)
+
+
+# ---------------------------------------------------------------------------
+# World Bible persistence
+# ---------------------------------------------------------------------------
+
+class TestBiblePersistence:
+    def test_incremental_write_and_read(self, tmp_path):
+        story = OverarchingStory(title="Persist Test", synopsis="S")
+        bible = create_world_bible(story)
+
+        add_room_to_bible(
+            bible, room_id="room_0", room_level=1, maze_environment="forest",
+            npc_pool=[{"id": 100, "selected": True}],
+            event_list=[{"id": "evt_0", "type": "combat", "monsters": []}],
+        )
+
+        path = str(tmp_path / "bible.json")
+        write_world_bible(bible, path)
+
+        with open(path) as f:
+            data = json.load(f)
+        assert data["story"]["title"] == "Persist Test"
+        assert "room_0" in data["rooms"]
+        assert "npc:100" in data["entity_index"]
+
+        # Add room 1 and re-write
+        add_room_to_bible(
+            bible, room_id="room_1", room_level=2, maze_environment="cave",
+            npc_pool=[{"id": 200, "selected": True}],
+        )
+        write_world_bible(bible, path)
+
+        with open(path) as f:
+            data = json.load(f)
+        assert "room_0" in data["rooms"]
+        assert "room_1" in data["rooms"]
+        assert "npc:200" in data["entity_index"]

--- a/tests/test_day_night.py
+++ b/tests/test_day_night.py
@@ -6,7 +6,7 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from src.models.time import DayNightCycle, TimePeriod
+from src.models.time import DayNightCycle, TimePeriod, DEFAULT_CYCLE_MS
 from src.systems.day_night import (
     apply_rest, apply_combat_rest, player_has_torch, consume_torch_use,
     is_event_active_at_time, is_npc_available, get_night_overlay_alpha,
@@ -47,107 +47,108 @@ class TestDayNightCycleModel:
         cycle = DayNightCycle()
         assert cycle.current_period == TimePeriod.DAWN
 
-    def test_advance_moves_ticks(self):
+    def test_advance_moves_elapsed(self):
         cycle = DayNightCycle()
+        ms_per_step = DEFAULT_CYCLE_MS // 200
         cycle.advance(10)
-        assert cycle.ticks == 10
+        assert cycle.elapsed_ms == ms_per_step * 10
 
     def test_period_transitions(self):
         """Verify periods transition at correct thresholds.
 
-        With cycle_length=200:
-          Dawn: 0-29 (15%)
-          Day: 30-99 (35%)
-          Dusk: 100-129 (15%)
-          Night: 130-199 (35%)
+        With default 960,000 ms cycle:
+          Dawn: 0 - 143,999 ms (15%)
+          Day: 144,000 - 479,999 ms (35%)
+          Dusk: 480,000 - 623,999 ms (15%)
+          Night: 624,000 - 959,999 ms (35%)
         """
-        cycle = DayNightCycle(cycle_length=200)
+        cycle = DayNightCycle()
 
-        cycle.ticks = 0
+        cycle.elapsed_ms = 0
         assert cycle.current_period == TimePeriod.DAWN
 
-        cycle.ticks = 29
+        cycle.elapsed_ms = 143_999
         assert cycle.current_period == TimePeriod.DAWN
 
-        cycle.ticks = 30
+        cycle.elapsed_ms = 144_000
         assert cycle.current_period == TimePeriod.DAY
 
-        cycle.ticks = 99
+        cycle.elapsed_ms = 479_999
         assert cycle.current_period == TimePeriod.DAY
 
-        cycle.ticks = 100
+        cycle.elapsed_ms = 480_000
         assert cycle.current_period == TimePeriod.DUSK
 
-        cycle.ticks = 129
+        cycle.elapsed_ms = 623_999
         assert cycle.current_period == TimePeriod.DUSK
 
-        cycle.ticks = 130
+        cycle.elapsed_ms = 624_000
         assert cycle.current_period == TimePeriod.NIGHT
 
-        cycle.ticks = 199
+        cycle.elapsed_ms = 959_999
         assert cycle.current_period == TimePeriod.NIGHT
 
     def test_cycle_wraps(self):
-        cycle = DayNightCycle(cycle_length=200)
-        cycle.ticks = 200  # Start of next cycle
+        cycle = DayNightCycle()
+        cycle.elapsed_ms = DEFAULT_CYCLE_MS  # Start of next cycle
         assert cycle.current_period == TimePeriod.DAWN
 
     def test_is_night(self):
-        cycle = DayNightCycle(cycle_length=200)
-        cycle.ticks = 150
+        cycle = DayNightCycle()
+        cycle.elapsed_ms = 700_000
         assert cycle.is_night
 
-        cycle.ticks = 50
+        cycle.elapsed_ms = 300_000
         assert not cycle.is_night
 
     def test_day_number(self):
-        cycle = DayNightCycle(cycle_length=200)
+        cycle = DayNightCycle()
         assert cycle.day_number == 1
 
-        cycle.ticks = 200
+        cycle.elapsed_ms = DEFAULT_CYCLE_MS
         assert cycle.day_number == 2
 
-        cycle.ticks = 599
+        cycle.elapsed_ms = DEFAULT_CYCLE_MS * 3 - 1
         assert cycle.day_number == 3
 
     def test_advance_hours(self):
-        cycle = DayNightCycle(cycle_length=200)
-        # 1 hour = 200/24 ≈ 8.33 ticks, 6 hours = int(8.33 * 6) = 50
+        cycle = DayNightCycle()
+        # 6 hours = 6/24 of cycle = 240,000 ms
         cycle.advance_hours(6)
-        assert cycle.ticks == 50
+        assert cycle.elapsed_ms == 240_000
 
     def test_period_progress(self):
-        cycle = DayNightCycle(cycle_length=200)
-        cycle.ticks = 0
+        cycle = DayNightCycle()
+        cycle.elapsed_ms = 0
         assert cycle.period_progress == pytest.approx(0.0)
 
-        # Midpoint of dawn (0-30): tick 15
-        cycle.ticks = 15
+        # Midpoint of dawn (0 to 144,000): 72,000 ms
+        cycle.elapsed_ms = 72_000
         assert cycle.period_progress == pytest.approx(0.5)
 
 
 class TestTimeAdvancesOnActions:
-    def test_movement_advances_time(self):
-        """Simulating that movement calls cycle.advance(1)."""
+    def test_real_time_update(self):
+        """Real-time update via update() method."""
         cycle = DayNightCycle()
-        initial = cycle.ticks
-        cycle.advance(1)  # One movement step
-        assert cycle.ticks == initial + 1
+        cycle.update(1000)  # Set baseline
+        cycle.update(2000)  # +1000 ms
+        assert cycle.elapsed_ms == 1000
 
     def test_combat_advances_time(self):
-        """Each combat turn should advance time."""
+        """Each combat turn calls advance(1)."""
         cycle = DayNightCycle()
-        # Simulate 5 combat turns
+        ms_per_step = DEFAULT_CYCLE_MS // 200
         for _ in range(5):
             cycle.advance(1)
-        assert cycle.ticks == 5
+        assert cycle.elapsed_ms == ms_per_step * 5
 
     def test_rest_advances_time(self):
         """Rest should advance time by hours."""
-        cycle = DayNightCycle(cycle_length=200)
-        initial = cycle.ticks
+        cycle = DayNightCycle()
+        initial = cycle.elapsed_ms
         cycle.advance_hours(6)
-        assert cycle.ticks > initial
+        assert cycle.elapsed_ms > initial
 
 
 class TestRestMechanic:
@@ -185,10 +186,10 @@ class TestRestMechanic:
 
     def test_rest_advances_time(self):
         player = _make_player()
-        cycle = DayNightCycle(cycle_length=200)
-        initial_ticks = cycle.ticks
+        cycle = DayNightCycle()
+        initial = cycle.elapsed_ms
         apply_rest(player, 6, cycle)
-        assert cycle.ticks > initial_ticks
+        assert cycle.elapsed_ms > initial
 
     def test_combat_rest(self):
         player = _make_player(health=50)
@@ -302,12 +303,19 @@ class TestNightOverlay:
 
 class TestDayNightSerialization:
     def test_round_trip(self):
-        cycle = DayNightCycle(cycle_length=200)
-        cycle.advance(75)
+        cycle = DayNightCycle()
+        cycle.elapsed_ms = 500_000
 
         data = cycle.serialize()
         restored = DayNightCycle.deserialize(data)
 
-        assert restored.ticks == 75
-        assert restored.cycle_length == 200
+        assert restored.elapsed_ms == 500_000
         assert restored.current_period == cycle.current_period
+
+    def test_legacy_round_trip(self):
+        """Legacy saves with ticks/cycle_length should load correctly."""
+        legacy_data = {"ticks": 75, "cycle_length": 200}
+        restored = DayNightCycle.deserialize(legacy_data)
+        # 75/200 = 37.5% of cycle = 360,000 ms -> Day period
+        assert restored.elapsed_ms == 360_000
+        assert restored.current_period == TimePeriod.DAY

--- a/tests/test_new_models.py
+++ b/tests/test_new_models.py
@@ -150,28 +150,30 @@ def test_save_state_with_data():
 def test_day_night_defaults():
     dnc = DayNightCycle()
     assert dnc.current_period == TimePeriod.DAWN
-    assert dnc.ticks == 0
+    assert dnc.elapsed_ms == 0
 
 
 def test_day_night_advance():
-    dnc = DayNightCycle(cycle_length=100)
-    # Period order: Dawn(15%) -> Day(35%) -> Dusk(15%) -> Night(35%)
-    # Dawn: 0-14, Day: 15-49, Dusk: 50-64, Night: 65-99
-    dnc.advance(15)
+    dnc = DayNightCycle()
+    # Period transitions with default 960,000 ms cycle:
+    # Dawn: 0 - 143,999 (15%), Day: 144,000 - 479,999 (35%)
+    # Dusk: 480,000 - 623,999 (15%), Night: 624,000 - 959,999 (35%)
+    dnc.elapsed_ms = 144_000
     assert dnc.current_period == TimePeriod.DAY
 
-    dnc.advance(35)  # ticks=50
+    dnc.elapsed_ms = 480_000
     assert dnc.current_period == TimePeriod.DUSK
 
-    dnc.advance(15)  # ticks=65
+    dnc.elapsed_ms = 624_000
     assert dnc.current_period == TimePeriod.NIGHT
 
 
 def test_day_night_full_cycle():
-    dnc = DayNightCycle(cycle_length=100)
+    dnc = DayNightCycle()
     periods_seen = set()
-    for _ in range(100):
-        dnc.advance(1)
+    # Sample 200 evenly spaced points across a full cycle
+    for i in range(200):
+        dnc.elapsed_ms = i * (dnc.cycle_duration_ms // 200)
         periods_seen.add(dnc.current_period)
     # Should cycle through all 4 periods
     assert TimePeriod.DAWN in periods_seen

--- a/tests/test_phase8_gaps.py
+++ b/tests/test_phase8_gaps.py
@@ -1,0 +1,291 @@
+"""Tests for Phase 8 gap fills: real-time day/night, night monsters,
+time-gated events, and NPC availability scheduling."""
+
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.models.time import DayNightCycle, TimePeriod, DEFAULT_CYCLE_MS
+from src.models.monster import (
+    Monster, generate_night_monster,
+    generate_night_variant, NIGHT_MONSTER_POOLS,
+)
+from src.models.encounter import Event, CombatEvent, PuzzleEvent, EventEncounter
+from src.models.npc import NPC, StaticNPC, MerchantNPC
+from src.systems.day_night import is_event_active_at_time, is_npc_available
+
+
+# ── Real-time DayNightCycle ──────────────────────────────────────────────
+
+
+class TestRealTimeCycle:
+    def test_starts_at_dawn(self):
+        cycle = DayNightCycle()
+        assert cycle.current_period == TimePeriod.DAWN
+
+    def test_update_advances_elapsed(self):
+        cycle = DayNightCycle()
+        cycle.update(1000)  # First call sets baseline
+        cycle.update(2000)  # Second call adds 1000 ms
+        assert cycle.elapsed_ms == 1000
+
+    def test_update_multiple_frames(self):
+        cycle = DayNightCycle()
+        cycle.update(100)  # First call sets baseline, no advance
+        cycle.update(200)  # +100
+        cycle.update(500)  # +300
+        assert cycle.elapsed_ms == 400
+
+    def test_period_transitions_real_time(self):
+        """With default 960,000 ms cycle:
+        Dawn: 0 - 143,999 ms (15%)
+        Day: 144,000 - 479,999 ms (35%)
+        Dusk: 480,000 - 623,999 ms (15%)
+        Night: 624,000 - 959,999 ms (35%)
+        """
+        cycle = DayNightCycle()
+        assert cycle.current_period == TimePeriod.DAWN
+
+        cycle.elapsed_ms = 143_999
+        assert cycle.current_period == TimePeriod.DAWN
+
+        cycle.elapsed_ms = 144_000
+        assert cycle.current_period == TimePeriod.DAY
+
+        cycle.elapsed_ms = 479_999
+        assert cycle.current_period == TimePeriod.DAY
+
+        cycle.elapsed_ms = 480_000
+        assert cycle.current_period == TimePeriod.DUSK
+
+        cycle.elapsed_ms = 623_999
+        assert cycle.current_period == TimePeriod.DUSK
+
+        cycle.elapsed_ms = 624_000
+        assert cycle.current_period == TimePeriod.NIGHT
+
+        cycle.elapsed_ms = 959_999
+        assert cycle.current_period == TimePeriod.NIGHT
+
+    def test_cycle_wraps(self):
+        cycle = DayNightCycle()
+        cycle.elapsed_ms = DEFAULT_CYCLE_MS  # Start of next cycle
+        assert cycle.current_period == TimePeriod.DAWN
+
+    def test_is_night(self):
+        cycle = DayNightCycle()
+        cycle.elapsed_ms = 700_000  # Well into night
+        assert cycle.is_night
+
+        cycle.elapsed_ms = 300_000  # Daytime
+        assert not cycle.is_night
+
+    def test_day_number(self):
+        cycle = DayNightCycle()
+        assert cycle.day_number == 1
+
+        cycle.elapsed_ms = DEFAULT_CYCLE_MS
+        assert cycle.day_number == 2
+
+        cycle.elapsed_ms = DEFAULT_CYCLE_MS * 3 - 1
+        assert cycle.day_number == 3
+
+    def test_advance_hours_jumps_forward(self):
+        cycle = DayNightCycle()
+        ms_per_hour = DEFAULT_CYCLE_MS / 24
+        cycle.advance_hours(6)
+        assert cycle.elapsed_ms == int(ms_per_hour * 6)
+
+    def test_advance_steps_for_combat(self):
+        cycle = DayNightCycle()
+        ms_per_step = DEFAULT_CYCLE_MS // 200
+        cycle.advance(5)
+        assert cycle.elapsed_ms == ms_per_step * 5
+
+    def test_period_progress(self):
+        cycle = DayNightCycle()
+        cycle.elapsed_ms = 0
+        assert cycle.period_progress == pytest.approx(0.0)
+
+        # Midpoint of dawn (0 to 144,000): 72,000 ms
+        cycle.elapsed_ms = 72_000
+        assert cycle.period_progress == pytest.approx(0.5)
+
+    def test_serialize_deserialize(self):
+        cycle = DayNightCycle()
+        cycle.elapsed_ms = 500_000
+        data = cycle.serialize()
+        restored = DayNightCycle.deserialize(data)
+        assert restored.elapsed_ms == 500_000
+        assert restored.current_period == cycle.current_period
+
+    def test_deserialize_legacy_ticks(self):
+        """Legacy saves with ticks/cycle_length should convert to elapsed_ms."""
+        legacy_data = {"ticks": 100, "cycle_length": 200}
+        cycle = DayNightCycle.deserialize(legacy_data)
+        # 100 / 200 = 0.5 of cycle = 480,000 ms
+        assert cycle.elapsed_ms == 480_000
+        assert cycle.current_period == TimePeriod.DUSK
+
+    def test_update_ignores_negative_delta(self):
+        cycle = DayNightCycle()
+        cycle.update(1000)
+        cycle.update(500)  # Time went backwards (shouldn't happen, but be safe)
+        assert cycle.elapsed_ms == 0
+
+
+# ── Night monster variants ───────────────────────────────────────────────
+
+
+class TestNightMonsterVariants:
+    def test_monster_has_time_availability_field(self):
+        m = Monster(species="Wolf", hp=10, max_hp=10)
+        assert m.time_availability == "always"
+
+    def test_generate_night_variant_stats(self):
+        base = Monster(
+            species="Wolf", name="Wolf", hp=20, max_hp=20,
+            str_mod=2, elemental_affinity=None, damage_type="physical",
+        )
+        variant = generate_night_variant(base)
+        assert variant.hp == 25  # 20 * 1.25
+        assert variant.max_hp == 25
+        assert variant.str_mod == 3  # 2 + 1
+        assert variant.elemental_affinity == "dark"
+        assert variant.damage_type == "dark"
+        assert variant.time_availability == "night"
+        assert variant.name.startswith("Nightstalker")
+        assert variant.species.startswith("Nightstalker")
+
+    def test_generate_night_variant_no_double_prefix(self):
+        base = Monster(
+            species="Wolf", name="Nightstalker Wolf",
+            hp=20, max_hp=20, str_mod=1,
+        )
+        variant = generate_night_variant(base)
+        assert variant.name == "Nightstalker Wolf"  # No double prefix
+
+    def test_generate_night_variant_unique_id(self):
+        base = Monster(species="Wolf", hp=10, max_hp=10)
+        variant = generate_night_variant(base)
+        assert variant.id != base.id
+
+    def test_generate_night_monster(self):
+        m = generate_night_monster("forest", 2)
+        assert m.time_availability == "night"
+        assert m.elemental_affinity == "dark"
+        assert m.damage_type == "dark"
+        assert m.species in NIGHT_MONSTER_POOLS["forest"]
+
+    def test_generate_night_monster_harder_stats(self):
+        """Night monsters should have +25% HP vs normal level scaling."""
+        # Generate many and check HP is boosted
+        monsters = [generate_night_monster("cave", 1) for _ in range(20)]
+        # Level 1 normal HP range: 8-12. With 1.25x: 10-15
+        for m in monsters:
+            assert m.hp >= 10  # int(8 * 1.25)
+
+    def test_night_monster_pools_all_environments(self):
+        """Every environment should have a night monster pool."""
+        from src.models.monster import MONSTER_POOLS
+        for env in MONSTER_POOLS:
+            assert env in NIGHT_MONSTER_POOLS, f"Missing night pool for {env}"
+
+    def test_monster_to_dict_includes_time_availability(self):
+        m = Monster(species="Wolf", hp=10, max_hp=10, time_availability="night")
+        d = m.to_dict()
+        assert d["time_availability"] == "night"
+
+    def test_monster_from_dict_time_availability(self):
+        d = {"species": "Wolf", "hp": 10, "max_hp": 10, "time_availability": "night"}
+        m = Monster.from_dict(d)
+        assert m.time_availability == "night"
+
+
+# ── Time-gated events ───────────────────────────────────────────────────
+
+
+class TestTimeGatedEvents:
+    def test_event_has_time_gate_field(self):
+        e = Event(id="test", type="combat", name="Test", description="desc")
+        assert e.time_gate is None
+
+    def test_event_time_gate_day(self):
+        e = Event(id="test", type="combat", name="Test", description="desc", time_gate="day")
+        assert e.time_gate == "day"
+        assert is_event_active_at_time(e, TimePeriod.DAY)
+        assert is_event_active_at_time(e, TimePeriod.DAWN)
+        assert not is_event_active_at_time(e, TimePeriod.NIGHT)
+        assert not is_event_active_at_time(e, TimePeriod.DUSK)
+
+    def test_event_time_gate_night(self):
+        e = Event(id="test", type="combat", name="Test", description="desc", time_gate="night")
+        assert is_event_active_at_time(e, TimePeriod.NIGHT)
+        assert is_event_active_at_time(e, TimePeriod.DUSK)
+        assert not is_event_active_at_time(e, TimePeriod.DAY)
+        assert not is_event_active_at_time(e, TimePeriod.DAWN)
+
+    def test_event_time_gate_none_always_active(self):
+        e = Event(id="test", type="combat", name="Test", description="desc")
+        for period in TimePeriod:
+            assert is_event_active_at_time(e, period)
+
+    def test_combat_event_inherits_time_gate(self):
+        ce = CombatEvent(id="c1", name="Fight", description="desc", time_gate="night")
+        assert ce.time_gate == "night"
+        assert is_event_active_at_time(ce, TimePeriod.NIGHT)
+        assert not is_event_active_at_time(ce, TimePeriod.DAY)
+
+    def test_puzzle_event_inherits_time_gate(self):
+        pe = PuzzleEvent(id="p1", name="Puzzle", description="desc", time_gate="day")
+        assert pe.time_gate == "day"
+        assert is_event_active_at_time(pe, TimePeriod.DAY)
+
+    def test_event_encounter_inherits_time_gate(self):
+        ee = EventEncounter(id="e1", name="Event", description="desc", time_gate="night")
+        assert ee.time_gate == "night"
+
+
+# ── NPC availability scheduling ──────────────────────────────────────────
+
+
+class TestNPCAvailability:
+    def test_npc_has_availability_field(self):
+        npc = NPC(x=0, y=0, id=1)
+        assert npc.availability is None
+
+    def test_npc_availability_day(self):
+        npc = NPC(x=0, y=0, id=1, availability="day")
+        assert is_npc_available(npc, TimePeriod.DAY)
+        assert is_npc_available(npc, TimePeriod.DAWN)
+        assert not is_npc_available(npc, TimePeriod.NIGHT)
+        assert not is_npc_available(npc, TimePeriod.DUSK)
+
+    def test_npc_availability_night(self):
+        npc = NPC(x=0, y=0, id=1, availability="night")
+        assert is_npc_available(npc, TimePeriod.NIGHT)
+        assert is_npc_available(npc, TimePeriod.DUSK)
+        assert not is_npc_available(npc, TimePeriod.DAY)
+        assert not is_npc_available(npc, TimePeriod.DAWN)
+
+    def test_npc_availability_always(self):
+        npc = NPC(x=0, y=0, id=1, availability="always")
+        for period in TimePeriod:
+            assert is_npc_available(npc, period)
+
+    def test_npc_availability_none_always_available(self):
+        npc = NPC(x=0, y=0, id=1)
+        for period in TimePeriod:
+            assert is_npc_available(npc, period)
+
+    def test_static_npc_availability(self):
+        npc = StaticNPC(x=0, y=0, id=1, availability="night")
+        assert not is_npc_available(npc, TimePeriod.DAY)
+        assert is_npc_available(npc, TimePeriod.NIGHT)
+
+    def test_merchant_npc_availability(self):
+        npc = MerchantNPC(x=0, y=0, id=1, availability="day")
+        assert is_npc_available(npc, TimePeriod.DAY)
+        assert not is_npc_available(npc, TimePeriod.NIGHT)


### PR DESCRIPTION
## Summary
- Converts DayNightCycle from action-based ticks to a real-time timer (~4 min per phase, ~16 min full cycle). Rest mechanic still jumps the timer forward. Legacy saves auto-convert on load.
- Adds night monster variants with `time_availability` field, `generate_night_variant()` function (+25% HP, +1 STR, dark elemental affinity, Nightstalker prefix), and night-only monster pools per environment. Combat encounters at night auto-upgrade monsters.
- Adds `time_gate` field to Event base class and pipeline assigns day/night gates to ~20% of events. Adds `availability` field to NPC model with pipeline assigning ~30% day-only, ~20% night-only, ~50% always.
- 36 new tests covering all three features; existing tests updated for real-time API.

## Test plan
- [x] All 829 tests pass
- [x] ruff check clean on all changed files
- [ ] Manual playtest: verify day/night transitions happen in real time (~4 min per phase)
- [ ] Manual playtest: verify Nightstalker variants appear in combat at night
- [ ] Manual playtest: verify time-gated events only trigger at correct time of day
- [ ] Manual playtest: verify NPCs show unavailable message at wrong time of day