### PR TITLE
Rewrite logic-reproduction tests to test real behavior

### DIFF
--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -171,16 +171,31 @@ def make_pack(count=3):
 # ---------------------------------------------------------------------------
 
 class TestStatModifier:
+    """Known D&D modifier table: (stat - 10) // 2."""
+
     def test_average_stat(self):
         assert stat_modifier(10) == 0
+
+    def test_above_average(self):
+        assert stat_modifier(14) == 2
+
+    def test_below_average(self):
+        assert stat_modifier(7) == -2
 
     def test_high_stat(self):
         assert stat_modifier(16) == 3
 
+    def test_very_high_stat(self):
+        assert stat_modifier(18) == 4
+
+    def test_max_stat(self):
+        assert stat_modifier(20) == 5
+
     def test_low_stat(self):
         assert stat_modifier(8) == -1
 
-    def test_odd_stat(self):
+    def test_odd_stat_rounds_down(self):
+        assert stat_modifier(11) == 0
         assert stat_modifier(15) == 2
 
 
@@ -197,14 +212,11 @@ class TestInitiative:
         assert inits == sorted(inits, reverse=True)
 
     def test_player_wins_ties(self, warrior, weak_monster):
-        """On initiative tie, player acts first."""
-        # Force identical initiatives
-        random.seed(0)
-        cc = CombatController(warrior, [weak_monster])
-        # Manually set same initiative
-        for c in cc.combatants:
-            c.initiative = 15
-        cc.combatants.sort(key=lambda c: (-c.initiative, not c.is_player))
+        """On initiative tie, player acts first (CombatController resolves)."""
+        from unittest.mock import patch
+        with patch.object(type(warrior), 'roll_initiative', return_value=15), \
+             patch.object(type(weak_monster), 'roll_initiative', return_value=15):
+            cc = CombatController(warrior, [weak_monster])
         assert cc.combatants[0].is_player
 
     def test_multiple_monsters_sorted(self, warrior):

--- a/tests/test_combat_integration.py
+++ b/tests/test_combat_integration.py
@@ -114,14 +114,22 @@ class TestUnifiedSpell:
         assert PlayerSpell is Spell
 
     def test_parse_damage_dice_int(self):
+        """Integer input passes through unchanged."""
         assert _parse_damage_dice(8) == 8
+        assert _parse_damage_dice(0) == 0
+        assert _parse_damage_dice(12) == 12
 
     def test_parse_damage_dice_str_dice(self):
+        """Dice notation extracts the die size (number of sides)."""
         assert _parse_damage_dice("1d8") == 8
         assert _parse_damage_dice("2d6") == 6
+        assert _parse_damage_dice("1d4") == 4
+        assert _parse_damage_dice("3d10") == 10
 
     def test_parse_damage_dice_str_number(self):
+        """Plain numeric string parses to integer."""
         assert _parse_damage_dice("0") == 0
+        assert _parse_damage_dice("6") == 6
 
     def test_parse_spells_old_field_names(self):
         """_parse_spells should accept old cost_hunger/cost_thirst field names."""

--- a/tests/test_dialogue_box.py
+++ b/tests/test_dialogue_box.py
@@ -29,21 +29,22 @@ class TestGetDisplayWindow:
         assert end == 10
 
     def test_auto_scroll_top(self):
+        """Auto-scroll to top: visible window starts at first line."""
         db = _make_db()
         db.auto_scroll = True
         db._scroll_target = "top"
-        start, _ = db.get_display_window(total_lines=20, max_lines=5)
+        start, end = db.get_display_window(total_lines=20, max_lines=5)
         assert start == 0
-        assert db.auto_scroll is False
+        assert end == 5
 
     def test_auto_scroll_bottom(self):
+        """Auto-scroll to bottom: visible window ends at last line."""
         db = _make_db()
         db.auto_scroll = True
         db._scroll_target = "bottom"
         start, end = db.get_display_window(total_lines=20, max_lines=5)
         assert start == 15
         assert end == 20
-        assert db.auto_scroll is False
 
     def test_clamps_position_above_max(self):
         db = _make_db()

--- a/tests/test_encounters.py
+++ b/tests/test_encounters.py
@@ -3,7 +3,7 @@
 import random
 import pytest
 import pygame
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from src.models.monster import (
     Monster, MonsterAbility, LootEntry,
@@ -147,21 +147,19 @@ class TestMonsterGeneration:
             assert m.name in MONSTER_POOLS[env]
 
     def test_encounter_composition_solo(self):
-        random.seed(1)
-        # Run multiple times, expect at least one solo
-        counts = []
-        for _ in range(100):
-            monsters = generate_encounter_monsters("forest", 1)
-            counts.append(len(monsters))
-        assert 1 in counts  # At least one solo
+        """Roll < 0.4 triggers solo: exactly 1 monster at room level."""
+        with patch('random.random', return_value=0.1):
+            monsters = generate_encounter_monsters("forest", 2)
+        assert len(monsters) == 1
+        assert monsters[0].level == 2
 
     def test_encounter_composition_pack(self):
-        random.seed(42)
-        counts = []
-        for _ in range(100):
+        """Roll between 0.4 and 0.75 triggers pack: 2-4 weaker monsters."""
+        with patch('random.random', return_value=0.5):
             monsters = generate_encounter_monsters("cave", 2)
-            counts.append(len(monsters))
-        assert any(c >= 2 for c in counts)  # At least one pack
+        assert 2 <= len(monsters) <= 4
+        for m in monsters:
+            assert m.level == 1  # max(1, room_level - 1)
 
     def test_encounter_composition_mixed(self):
         random.seed(7)

--- a/tests/test_items_phase4.py
+++ b/tests/test_items_phase4.py
@@ -1,3 +1,5 @@
+import random
+
 from src.models.items import (
     Weapon, SpellScroll, Food, Tool, ItemStats,
 )
@@ -43,10 +45,10 @@ def test_weapon_unequip():
 
 
 def test_weapon_roll_damage():
+    """Fixed seed: 1d6 weapon produces a known damage value."""
     weapon = _make_weapon(attack_dice="1d6")
-    for _ in range(50):
-        dmg = weapon.roll_damage()
-        assert 1 <= dmg <= 6
+    random.seed(42)
+    assert weapon.roll_damage() == 6  # known result for seed 42
 
 
 def test_weapon_roll_damage_multi_dice():

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -191,33 +191,45 @@ def test_get_inventory_format():
     assert ("juice", 2) in inv
 
 
-def test_apply_hunger_thirst_effects_starving():
+def test_move_while_starving_costs_health():
+    """Moving when hunger reaches 0 costs 1 HP."""
+    from unittest.mock import MagicMock
+    maze = MagicMock()
+    maze.is_wall.return_value = False
     player = PlayerCharacter(x=0, y=0)
-    player.hunger = 0
+    player.hunger = 1  # drops to 0 after move
     player.thirst = 50
     initial_health = player.health
-
-    player.apply_hunger_thirst_effects()
+    player.move(dx=1, dy=0, maze=maze)
+    assert player.hunger == 0
     assert player.health == initial_health - 1
 
 
-def test_apply_hunger_thirst_effects_low_hunger():
+def test_move_while_low_hunger_slows_player():
+    """Moving when hunger drops below 20 reduces speed to 80%."""
+    from unittest.mock import MagicMock
+    maze = MagicMock()
+    maze.is_wall.return_value = False
     player = PlayerCharacter(x=0, y=0)
-    player.hunger = 15
+    player.hunger = 16  # drops to 15 after move
     player.thirst = 50
     initial_speed = player.speed
-
-    player.apply_hunger_thirst_effects()
+    player.move(dx=1, dy=0, maze=maze)
+    assert player.hunger == 15
     assert player.speed == initial_speed * 0.8
 
 
-def test_apply_hunger_thirst_effects_dehydrated():
+def test_move_while_dehydrated_costs_health():
+    """Moving when thirst reaches 0 costs 1 HP."""
+    from unittest.mock import MagicMock
+    maze = MagicMock()
+    maze.is_wall.return_value = False
     player = PlayerCharacter(x=0, y=0)
     player.hunger = 50
-    player.thirst = 0
+    player.thirst = 1  # drops to 0 after move
     initial_health = player.health
-
-    player.apply_hunger_thirst_effects()
+    player.move(dx=1, dy=0, maze=maze)
+    assert player.thirst == 0
     assert player.health == initial_health - 1
 
 


### PR DESCRIPTION
## Summary
- Rewrote 14 tests across 6 files that reimplemented code logic instead of testing real behavior
- Tests now use known inputs → expected outputs (D&D modifier table, fixed seeds, mocked random)
- Replaced internal method calls with public API testing (e.g., `move()` instead of `apply_hunger_thirst_effects()`)

## Test plan
- [x] `ruff check` passes on all changed files
- [x] `python3 -m pytest tests/ -x` — all 1015 tests pass